### PR TITLE
프로필 편집탭에서 다른탭으로 이동후 넘어오면 가입중인 동아리가 중복해서 늘어나는 버그 수정

### DIFF
--- a/app/src/views/assets/js/profile/profile_edit.js
+++ b/app/src/views/assets/js/profile/profile_edit.js
@@ -43,7 +43,7 @@ function collectClubNames() {
 // 새로운 클럽 입력 필드 추가하는 함수
 function addClubInput(clubName) {
     const newInputGroup = document.createElement('div');
-    newInputGroup.classList.add('input-group', 'mb-3');
+    newInputGroup.classList.add('input-group', 'mb-3', 'input-group-added');
     newInputGroup.innerHTML = `
         <input type="text" class="form-control" name="clubs[]" value="${clubName}" placeholder="동아리명">
         <button class="btn btn-outline-secondary remove-club-btn" type="button">-</button>
@@ -56,6 +56,12 @@ function createProfileElements(profileData) {
     document.getElementById('Twitter').value = profileData.twitter_link || '';
     document.getElementById('Facebook').value = profileData.facebook_link || '';
     document.getElementById('Instagram').value = profileData.instagram_link || '';
+
+    // 기존에 추가된 입력 필드만 제거
+    const existingInputs = container.querySelectorAll('.input-group-added');
+    existingInputs.forEach(inputGroup => {
+        inputGroup.remove();
+    });
 
     const joinedClubs = profileData.joined_clubs ? profileData.joined_clubs.split(',') : [];
     joinedClubs.forEach(clubName => {


### PR DESCRIPTION
현재 프로필 편집탭에서 프로필을 저장하지 않고 다른 탭(미리보기, 비밀번호 변경) 으로 갔다가 다시 프로필 편집으로 왔을때 가입중인 동아리 input이 계속해서 2배씩 늘어나는 버그를 수정하였습니다