### PR TITLE
connectionLimit의 값이 너무 작아서 웹사이트에서 지연시간이 발생하여 값을 추가

### DIFF
--- a/app/src/config/database.js
+++ b/app/src/config/database.js
@@ -3,7 +3,7 @@ const dotenv = require("dotenv");
 dotenv.config();
 
 const pool = mysql.createPool({
-  connectionLimit: 10,
+  connectionLimit: 50,
   host: process.env.DB_HOST,
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,


### PR DESCRIPTION
connectionLimit의 값이 너무 작아서 웹사이트에서 지연시간이 발생하여 값을 늘렸습니다.

기존의 connectionLimit 값이 10이였는데,
50으로 늘려서 현재 증상이 완화되었는데, 추후 또 지연시간이 발생하면 말씀 부탁드립니다!