### PR TITLE
게시글을 삭제,편집 구현 완료

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -21,8 +21,9 @@ const usersProfileRoutes = require('./src/routes/users-profile.route');
 const writePostRoutes = require('./src/routes/post/postRecruit/write-post.route');
 const clubAdminRoutes = require('./src/routes/pages-clubAdmin.route');
 const searchRoutes = require('./src/routes/search/search.route');
-const postRotes = require('./src/routes/post/postRecruit/view-post.route');
+const viewPostRoutes = require('./src/routes/post/postRecruit/view-post.route');
 const indexPostDashboard = require('./src/routes/post/index.postDashboard.route');
+const editPostRoutes = require('./src/routes/post/postRecruit/edit-post.route')
 
 //미들웨어
 app.use(express.json());
@@ -53,8 +54,9 @@ app.use(usersProfileRoutes);
 app.use(writePostRoutes);
 app.use(clubAdminRoutes);
 app.use(searchRoutes);
-app.use(postRotes);
+app.use(viewPostRoutes);
 app.use(indexPostDashboard);
+app.use(editPostRoutes);
 
 app.set("view engine", "ejs");
 app.set("views", path.join(__dirname, "src/views/ejs-file"));

--- a/app/src/controllers/postCtrollers/index.postDashboard.ctrl.js
+++ b/app/src/controllers/postCtrollers/index.postDashboard.ctrl.js
@@ -12,7 +12,7 @@ const getRecruitPostList = (req, res) => {
                     handleDBError(`글을 불러오는 중 에러 발생: ${err}`);
                     return;
                 }
-                if(result.length === 0 ){
+                if (result.length === 0) {
                     RecruitPostsData.success = false;
                     return res.json(RecruitPostsData);
                 }
@@ -20,7 +20,7 @@ const getRecruitPostList = (req, res) => {
                 RecruitPostsData.postData = result;
                 //postingData.postData에 이미 content라는 키값이 있는데 안에 내용을 변경.
                 //문자열로 되어있어서 json객체로 변경해서 덮어씌움
-                for(let idx = 0; idx<result.length; idx++){
+                for (let idx = 0; idx < result.length; idx++) {
                     RecruitPostsData.postData[idx].content = JSON.parse(result[idx].content);
                 }
                 res.json(RecruitPostsData);

--- a/app/src/controllers/postCtrollers/postRecruitControllers/editPost.ctrl.js
+++ b/app/src/controllers/postCtrollers/postRecruitControllers/editPost.ctrl.js
@@ -1,0 +1,168 @@
+const { executeQuery } = require("../../../config/database.func");
+const { handleDBError } = require("../../../controllers/login.ctrl");
+const { getTokenDecode } = require("../../tokenControllers/token.ctrl");
+const { verifyClubAdmin, verifyClubMemberAdminAc, getClubCategory } = require("./writePost.ctrl");
+
+const setPostUpdate = async (req, res) => {
+    const editPostData = req.body;
+    const resData = {};
+
+    const postNum = req.query.query;
+    try {
+        const decodedToken = await getTokenDecode(req, res);
+        const user_id = decodedToken.id;
+        const clubCategory = await getClubCategory(editPostData.club_name);
+
+        const isClubOwner = await verifyClubAdmin(user_id, editPostData.club_name);
+        const isClubAcminAc = await verifyClubMemberAdminAc(clubCategory, decodedToken.studentId);
+        if (!isClubOwner && !isClubAcminAc) {
+            resData.isClubAdminAc = false;
+            return res.json(resData);
+        }
+        resData.isClubAdminAc = true;
+
+        executeQuery("UPDATE post_recruit SET title = ?, club_name = ?, content = ?, recruit_num = ?, dead_day = ?, writer = ?, image_route = ?, category = ? WHERE post_number = ?",
+            [
+                editPostData.title,
+                editPostData.club_name,
+                editPostData.content,
+                editPostData.recruit_num,
+                editPostData.dead_day,
+                user_id,
+                editPostData.image_route,
+                clubCategory,
+                postNum // 게시글을 식별할 수 있는 고유 ID
+            ],
+            (err, result) => {
+                if (err) {
+                    handleDBError(`포스팅 게시글 DB를 업데이트할 때 에러 발생: ${err}`);
+                    resData.success = false;
+                    return res.json(resData);
+                }
+                if (result.affectedRows === 0) {
+                    // 업데이트할 게시글이 없는 경우
+                    console.error("업데이트할 게시글이 존재하지 않습니다.");
+                    resData.success = false;
+                    return res.json(resData);
+                }
+                // 성공적으로 업데이트된 경우
+                resData.success = true;
+                resData.postNum = postNum; // 업데이트된 게시글 ID
+                res.json(resData);
+            })
+    } catch (err) {
+        console.error("게시글 편집 실패", err);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const setDeletePost = async (req, res) => {
+    const deletePostNumber = req.body;
+    const resData = {};
+
+    try {
+        executeQuery("DELETE FROM post_recruit WHERE post_number = ?;",
+            [deletePostNumber.postNum],
+            (err, result) => {
+                if (err) {
+                    handleDBError(`포스팅 게시글 DB를 업데이트할 때 에러 발생: ${err}`);
+                    resData.success = false;
+                    return res.json(resData);
+                }
+                if (result.affectedRows === 0) {
+                    // 삭제할 게시글이 없는 경우
+                    console.error("삭제할 게시글이 존재하지 않습니다.");
+                    resData.success = false;
+                    return res.json(resData);
+                }
+                // 성공적으로 삭제된 경우
+                resData.success = true;
+                res.json(resData);
+            })
+    } catch (err) {
+        console.error("게시글 편집 실패", err);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+async function getPostCategory(post_number) {
+    return new Promise((resolve, reject) => {
+        executeQuery('SELECT category FROM post_recruit WHERE post_number=?;',
+            [post_number],
+            (err, result) => {
+                if (err) {
+                    handleDBError(err);
+                    return reject(err);
+                }
+                resolve(result[0].category);
+            }
+        )
+    })
+}
+
+//해당 게시글의 편집모드로 들어갈때 접속자가 해당 게시글의 Owner인지 확인
+async function isPostClubOwner(category, user_id) {
+    return new Promise((resolve, reject) => {
+        executeQuery('SELECT club_owner FROM club WHERE category = ? AND club_owner = ?;',
+            [category, user_id],
+            (err, result) => {
+                if (err) {
+                    handleDBError(err);
+                    return reject(err);
+                }
+                if (result.length === 0) {
+                    resolve(false);
+                } else {
+                    resolve(true);
+                }
+            })
+    })
+}
+
+async function isPostAdminAc(category, userId) {
+    return new Promise((resolve, reject) => {
+        executeQuery('SELECT admin_ac FROM club_member WHERE category = ? AND user_id = ?;',
+            [category, userId],
+            (err, result) => {
+                if (err) {
+                    handleDBError(err);
+                    return reject(err);
+                }
+                if (result.length === 0) {
+                    resolve(false);
+                } else {
+                    resolve(true);
+                }
+            })
+    })
+}
+
+//해당 게시글의 편집모드로 들어갈때, 접속자가 해당 게시글의 권한자(owner || admin_ac)인지 확인
+const verifyEditAccess = async (req, res) => {
+    try {
+        const decodedToken = await getTokenDecode(req, res);
+        const user_id = decodedToken.id;
+        const query = req.query.query;
+
+        const category = await getPostCategory(query);
+        const checkPostClubOwner = await isPostClubOwner(category, user_id);
+        const checkPostAdminAc = await isPostAdminAc(category, user_id);
+
+        if (!checkPostClubOwner && !checkPostAdminAc) {
+            return res.json({ isAccess: false });
+        }
+        res.json({ isAccess: true });
+
+    } catch (error) {
+        console.error("권한자 조회중 에러발생:", error);
+        return res.json({ isAccess: false });
+    }
+}
+
+module.exports = {
+    setPostUpdate,
+    verifyEditAccess,
+    setDeletePost,
+}

--- a/app/src/controllers/postCtrollers/postRecruitControllers/viewPost.ctrl.js
+++ b/app/src/controllers/postCtrollers/postRecruitControllers/viewPost.ctrl.js
@@ -1,40 +1,5 @@
 const { executeQuery } = require("../../../config/database.func");
 const { handleDBError } = require("../../login.ctrl");
-const { getTokenDecode } = require("../../tokenControllers/token.ctrl");
-
-const getPost = async (req, res) => {
-    try {
-        const postingData = {};
-        const accessToken = await getTokenDecode(req, res);
-        const writer = accessToken.id;
-
-        executeQuery(
-            "SELECT * FROM post_recruit WHERE writer = ? ORDER BY post_number DESC LIMIT 1;",
-            [writer],
-            (err, result) => {
-                if (err) {
-                    handleDBError(`글을 불러오는 중 에러 발생: ${err}`);
-                    return;
-                }
-                if (!result || result.length === 0) {
-                    postingData.success = false;
-                    return res.json(postingData);
-                }
-                postingData.success = true;
-                postingData.postData = result[0];
-
-                // const content = JSON.parse(result[0].content);
-                // postingData.content = content;
-
-                //postingData.postData에 이미 content라는 키값이 있는데 안에 내용을 변경.
-                //문자열로 되어있어서 json객체로 변경해서 덮어씌움
-                postingData.postData.content = JSON.parse(result[0].content);
-                res.json(postingData);
-            })
-    } catch (error) {
-        console.error("게시글 불러오기 실패", error);
-    }
-}
 
 const getViewRecruitPostFromNum = async (req, res) => {
     const postNum = req.query.query;
@@ -66,6 +31,5 @@ const getViewRecruitPostFromNum = async (req, res) => {
 }
 
 module.exports = {
-    getPost,
     getViewRecruitPostFromNum,
 };

--- a/app/src/controllers/postCtrollers/postRecruitControllers/writePost.ctrl.js
+++ b/app/src/controllers/postCtrollers/postRecruitControllers/writePost.ctrl.js
@@ -43,6 +43,26 @@ function verifyClubAdmin(user_id, club_name) {
     });
 }
 
+//해당 아이디의 유저가 카테고리 동아리의 Admin_ac를 체크.
+function verifyClubMemberAdminAc(category, studentId){
+    return new Promise((resolve, reject) => {
+        executeQuery('SELECT admin_ac FROM club_member WHERE category = ? AND member_student_id = ?;',
+        [category, studentId],
+        (err, result) => {
+            if (err) {
+                handleDBError(err);
+                reject(err);
+            } else {
+                if (result.length === 0 || !result[0].admin_ac) {
+                    resolve(false); // 해당 동아리에 admin_ac 권한이 없음.
+                } else {
+                    resolve(true); // 해당 동아리에 admin_ac 권한이 있음.
+                }
+            }
+        });
+    })
+}
+
 const createPost = async (req, res) => {
     const postData = req.body;
     const resData = {};
@@ -75,6 +95,7 @@ const createPost = async (req, res) => {
                     return res.json(resData);
                 }
                 resData.success = true;
+                resData.postNum = result.insertId;
                 res.json(resData);
             })
     } catch (err) {
@@ -105,4 +126,6 @@ module.exports = {
     createPost,
     getClubCategory,
     checkClubOwner,
+    verifyClubAdmin,
+    verifyClubMemberAdminAc,
 };

--- a/app/src/controllers/tokenControllers/token.ctrl.js
+++ b/app/src/controllers/tokenControllers/token.ctrl.js
@@ -92,9 +92,27 @@ const verifyToken = (req, res, next) => {
     }
 };
 
+//로그인 검증, 클라이언트 측에서 지금 로그인된건지 확인하는 미들웨어.
+const isLogin = (req, res, next) => {
+    const token = req.cookies.accessToken;
+    // JWT가 없는 경우
+    if (!token) {
+        return res.json({ isLogin: false });
+    }
+    try {
+        // JWT를 검증하여 페이로드(사용자 정보)를 추출
+        const decoded = jwt.verify(token, process.env.ACCESS_SECRET);
+        req.user = decoded; // 추출한 사용자 정보를 요청 객체에 저장
+        res.json({ isLogin: true });
+        next(); // 다음 미들웨어로 이동
+    } catch (err) {
+        res.json({ isLogin: false });
+    }
+};
 
 module.exports = {
     refreshTokenMiddleware,
     getTokenDecode,
     verifyToken,
+    isLogin,
 };

--- a/app/src/routes/pages-login.route.js
+++ b/app/src/routes/pages-login.route.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const loginController = require("../controllers/login.ctrl");
+const { isLogin } = require("../controllers/tokenControllers/token.ctrl")
 
 router.get("/pages-login", (req, res) => {
     res.render("pages-login");
@@ -15,8 +16,8 @@ router.get('/api/auth/refresh-token', loginController.refreshToken);
 router.post('/api/auth/refresh-token', loginController.refreshToken);
 
 router.get('/api/users/logout', loginController.logout);
-// router.post('/api/users/logout', loginController.logout);
 
-// router.get('/login/success', loginController.loginSuccess);
+//로그인이 되었는지 확인 하는 API, 현재 로그인이 되어있으면 isLogin키값이 T/F로 응답함.
+router.get('/isLogin', isLogin)
 
 module.exports = router;

--- a/app/src/routes/post/postRecruit/edit-post.route.js
+++ b/app/src/routes/post/postRecruit/edit-post.route.js
@@ -1,0 +1,16 @@
+const express = require("express");
+const router = express.Router();
+const { verifyToken } = require('../../../controllers/tokenControllers/token.ctrl');
+const { setPostUpdate, verifyEditAccess, setDeletePost } = require('../../../controllers/postCtrollers/postRecruitControllers/editPost.ctrl');
+
+router.get("/edit-post", verifyToken, (req, res) => {
+    res.render("./post/post-recruit/edit-post");
+});
+
+router.post("/post-update", setPostUpdate);
+
+router.get("/verifyEditAccess", verifyEditAccess);
+
+router.post("/post-delete", setDeletePost);
+
+module.exports = router;

--- a/app/src/routes/post/postRecruit/view-post.route.js
+++ b/app/src/routes/post/postRecruit/view-post.route.js
@@ -1,23 +1,10 @@
 const express = require('express');
 const router = express.Router();
-const { getPost, getViewRecruitPostFromNum } = require('../../../controllers/postCtrollers/postRecruitControllers/viewPost.ctrl');
-const { verifyToken } = require('../../../controllers/tokenControllers/token.ctrl');
+const { getViewRecruitPostFromNum } = require('../../../controllers/postCtrollers/postRecruitControllers/viewPost.ctrl');
 
-router.get('/userPosts', verifyToken, getPost);
-
-//최근에 작성한 게시글 홍보글로 이동
-router.get('/view-current-recruit-post', (req, res, next) => {
-    // query가 있는 경우
-    if (req.query.query) {
-        // verifyToken을 실행하지 않고 다음 미들웨어 함수로 이동
-        return next();
-    } else {
-        // query가 없는 경우 verifyToken 실행
-        verifyToken(req, res, next);
-    }
-}, (req, res) => {
+router.get('/view-recruit-post', (req, res) => {
     res.render('./post/post-recruit/view-post');
-});
+})
 
 //post_number를 기준으로 홍보게시판을 보여준다.
 router.get('/view-recruit-post-from-postNum', getViewRecruitPostFromNum);

--- a/app/src/views/assets/js/post/index.postDashboard.js
+++ b/app/src/views/assets/js/post/index.postDashboard.js
@@ -8,34 +8,36 @@ function createCard(data) {
     const cardContainer = document.getElementById("card-container");
 
     const cardCol = document.createElement("div");
-    cardCol.classList.add("col");
-    cardCol.setAttribute('id', `post_number-${data.post_number}`); // 고유한 ID 할당
+    cardCol.classList.add("col", "mb-4");
+    cardCol.setAttribute('id', `post_number-${data.post_number}`);
 
     const card = document.createElement("div");
-    card.classList.add("card", "clickable-card", "team-card");
+    card.classList.add("card", "clickable-card", "team-card", "shadow-sm");
     card.style.maxWidth = "540px";
 
-    // 작성일과 마감일 표시
     const createDay = new Date(data.create_day).toLocaleDateString();
     const deadDay = new Date(data.dead_day).toLocaleDateString();
 
+    const writer = `<span class="badge bg-secondary">작성자: ${data.writer}</span>`;
+
     const cardContent = `
         <div class="row g-0">
-        <a href="/view-current-recruit-post?query=${data.post_number}">
-            <div class="col-md-4">
-                <img src="assets/img/card.jpg" class="img-fluid rounded-start">
-            </div>
-            <div class="col-md-8">
-                <div class="card-body">
-                    <h5 class="card-title mb-3">${data.club_name}</h5>
-                    <h6 class="card-subtitle mb-3 text-muted">${data.title}</h6>
-                    <p class="card-text mb-2"><strong>모집인원:</strong> ${data.recruit_num}명</p>
-                    <p class="card-text mb-2"><strong>게시일:</strong> ${createDay}</p>
-                    <p class="card-text mb-2"><strong>모집 종료일:</strong> ${deadDay}</p>
-                    <p class="card-text text-truncate">${textContent}</p>
-                    <span class="badge bg-secondary position-absolute top-0 end-0">게시글 번호: ${data.post_number}</span>
+            <a href="/view-recruit-post?query=${data.post_number}" class="text-decoration-none">
+                <div class="col-md-4">
+                    <img src="assets/img/card.jpg" class="img-fluid rounded-start">
                 </div>
-            </div>
+                <div class="col-md-8">
+                    <div class="card-body">
+                        <h5 class="card-title text-dark mb-2">${data.club_name}</h5>
+                        <h6 class="card-subtitle mb-2 text-muted">${data.title}</h6>
+                        <div class="mb-2">${writer}</div>
+                        <p class="card-text mb-1"><strong>모집인원:</strong> ${data.recruit_num}명</p>
+                        <p class="card-text mb-1"><strong>게시일:</strong> ${createDay}</p>
+                        <p class="card-text mb-1"><strong>모집 종료일:</strong> ${deadDay}</p>
+                        <p class="card-text mb-3 text-truncate">${textContent}</p>
+                        <span class="badge bg-info position-absolute top-0 end-0 m-2">번호: ${data.post_number}</span>
+                    </div>
+                </div>
             </a>
         </div>
     `;

--- a/app/src/views/assets/js/post/post-recruit/editPost.js
+++ b/app/src/views/assets/js/post/post-recruit/editPost.js
@@ -1,0 +1,237 @@
+// 폼 유효성 검사 함수
+function validateForm() {
+    let form = document.querySelector(".needs-validation");
+    let inputs = form.querySelectorAll("[required]");
+    let isValid = true;
+
+    inputs.forEach(function (input) {
+        if (!input.value.trim()) {
+            input.classList.add("is-invalid");
+            isValid = false;
+        } else {
+            input.classList.remove("is-invalid");
+            input.classList.add("is-valid"); // Add is-valid class for valid input
+        }
+    });
+
+    return isValid;
+}
+
+// 해당 동아리에 대표가 아닌 경우
+function addInvalidFeedback(input, message) {
+    const invalidFeedback = input.nextElementSibling;
+    input.classList.add('is-invalid');
+    invalidFeedback.textContent = message;
+}
+
+function quillGetEditor() {
+    let editor = document.querySelector('#editor');
+    if (!editor.__quill) { // 에디터가 이미 초기화되지 않았다면 초기화
+        let quill = new Quill(editor, {
+            theme: 'snow', // 테마 설정
+            modules: { // 모듈 설정
+                toolbar: [ // 툴바 설정
+                    // 텍스트 스타일링
+                    ['bold', 'italic', 'underline', 'strike'],
+                    // 리스트
+                    [{ 'list': 'ordered' }, { 'list': 'bullet' }],
+                    // 들여쓰기
+                    [{ 'indent': '-1' }, { 'indent': '+1' }],
+                    // 링크
+                    ['link'],
+                    // 이미지
+                    ['image'],
+                    // 줄 간격
+                    [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+                    // 글자색, 배경색
+                    [{ 'color': [] }, { 'background': [] }],
+                    // 정렬
+                    [{ 'align': [] }]
+                ],
+            },
+            placeholder: '내용을 입력해주세요.',
+        });
+        editor.__quill = quill;
+    }
+    return editor.__quill;
+}
+
+function setPostingInfo(postData) {
+    // 동아리 이름과 제목 설정
+    document.getElementById('dongariName').value = postData.club_name;
+    document.getElementById('postTitle').value = postData.title;
+
+    // 모집 인원 설정
+    document.getElementById('recruitNumber').value = postData.recruit_num;
+
+    // 작성일과 마감일 설정
+    document.getElementById('recruitDeadline').value = new Date(postData.dead_day).toISOString().slice(0, 10);
+
+    // Quill Editor 내용 설정
+    const quillEditor = quillGetEditor(); // 에디터 초기화 및 인스턴스 가져오기
+    quillEditor.setContents(postData.content);
+}
+
+function getPostData() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const postNum = urlParams.get('query');
+    fetch(`/view-recruit-post-from-postNum?query=${postNum}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+        .then(res => {
+            if (!res.ok) {
+                throw new Error('네트워크 응답이 올바르지 않습니다.');
+            }
+            return res.json();
+        })
+        .then(data => {
+            if (!data.success) {
+                alert("수정할 수 있는 게시글을 찾을 수 없습니다.");
+                window.location.href = "/";
+            }
+            setPostingInfo(data.postData);
+        })
+        .catch(error => {
+            console.error('게시글 수정 중 오류 발생:', error);
+        });
+}
+
+function setPostUpdate(event) {
+    event.preventDefault(); // Prevent form submission if there are invalid inputs
+
+    if (!validateForm()) {
+        return;
+    }
+
+    // quillGetEditor 함수를 호출하여 Quill 에디터의 인스턴스를 가져옴
+    const quillEditor = quillGetEditor();
+
+    // Quill 에디터의 내용을 Delta 형식으로 가져옴
+    const quillContents = quillEditor.getContents();
+
+    const postingData = {
+        title: document.getElementById('postTitle').value,
+        club_name: document.getElementById('dongariName').value,
+        recruit_num: document.getElementById('recruitNumber').value,
+        dead_day: document.getElementById('recruitDeadline').value,
+        image_route: null,
+        // Delta 형식의 데이터를 JSON 문자열로 변환하여 전송
+        content: JSON.stringify(quillContents),
+    };
+    const urlParams = new URLSearchParams(window.location.search);
+    const postNum = urlParams.get('query');
+    fetch(`/post-update?query=${postNum}`, {
+        method: 'POST',
+        body: JSON.stringify(postingData),
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('네트워크 응답이 올바르지 않습니다.');
+            }
+            return response.json();
+        })
+        .then(data => {
+            console.log(data);
+            if (!data.isClubAdminAc) {
+                // 해당 동아리에 권한자가 아닌 경우
+                const dongariNameInput = document.getElementById('dongariName');
+                addInvalidFeedback(dongariNameInput, '해당 동아리에 권한자가 아닙니다.');
+                return;
+            }
+            if (!data.success) {
+                alert('게시글 작성에 실패하였습니다.');
+                return;
+            }
+            alert('게시글 수정에 성공하셨습니다!');
+            window.location.href = `/view-recruit-post?query=${data.postNum}`;
+        })
+        .catch(err => {
+            alert(`에러발생: ${err}`);
+            window.location.href = "/";
+        })
+}
+
+function deletePost(postNum) {
+    fetch(`/post-delete`, {
+        method: 'POST',
+        body: JSON.stringify({postNum: postNum}),
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        return response.json();
+    })
+    .then(data => {
+        if(!data.success){
+            alert('게시글 삭제에 실패하였습니다.');
+            return;
+        }
+        alert('게시글이 삭제되었습니다!');
+        window.location.href = "/";
+    })
+    .catch(err => {
+        alert(`에러발생: ${err}`);
+        window.location.href = "/";
+    })
+}
+
+//해당 게시글의 편집모드로 들어갈때, 접속자가 해당 게시글의 권한자(owner || admin_ac)인지 확인
+function verifyEditAccess() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const postNum = urlParams.get('query');
+
+    fetch(`/verifyEditAccess?query=${postNum}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('네트워크 응답이 올바르지 않습니다.');
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (!data.isAccess) {
+                alert('해당 게시글을 수정하실 권한이 없습니다.');
+                window.location.href = "/";
+            }
+        })
+        .catch(err => {
+            alert(`에러발생: ${err}`);
+            window.location.href = "/";
+        })
+}
+
+// DOMContentLoaded 이벤트 리스너
+document.addEventListener('DOMContentLoaded', () => {
+    verifyEditAccess();
+    getPostData();
+
+    const savePostBtn = document.getElementById('save_post_button');
+    savePostBtn.addEventListener('click', setPostUpdate);
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const postNum = urlParams.get('query');
+
+    const cancelPostBtn = document.getElementById('cancel_post_button');
+    cancelPostBtn.addEventListener('click', () => {
+        window.location.href = `/view-recruit-post?query=${postNum}`;
+    })
+
+    const deletePostBtn = document.getElementById('realDeleteBtn');
+    deletePostBtn.addEventListener('click', () => {
+        deletePost(postNum);
+    });
+});

--- a/app/src/views/assets/js/post/post-recruit/writePost.js
+++ b/app/src/views/assets/js/post/post-recruit/writePost.js
@@ -73,7 +73,7 @@ function submitPostData(event) {
                 return;
             }
             alert('게시글 등록에 성공하였습니다.');
-            window.location.href = "/view-current-recruit-post";
+            window.location.href = `/view-recruit-post?query=${data.postNum}`;
         })
         .catch(error => {
             console.error('오류 발생:', error.message);

--- a/app/src/views/ejs-file/post/post-recruit/edit-post.ejs
+++ b/app/src/views/ejs-file/post/post-recruit/edit-post.ejs
@@ -5,11 +5,11 @@
         <main id="main" class="main">
 
             <div class="pagetitle">
-                <h1>동아리 모집 게시글 작성</h1>
+                <h1>동아리 모집 게시글 수정</h1>
                 <nav>
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="/">Home</a></li>
-                        <li class="breadcrumb-item active">동아리 모집 게시글 작성</li>
+                        <li class="breadcrumb-item active">동아리 모집 게시글 수정</li>
                     </ol>
                 </nav>
             </div><!-- End Page Title -->
@@ -19,7 +19,7 @@
                     <div class="card mb-3">
                         <div class="card-body">
                             <div class="pt-1 pb-2">
-                                <h5 class="card-title text-center pb-0 fs-4">동아리 모집 게시글 작성</h5>
+                                <h5 class="card-title text-center pb-0 fs-4">동아리 모집 게시글 수정</h5>
                                 <form method="POST" class="row g-3 needs-validation" novalidate>
                                     <div class="col-12">
                                         <label for="postTitle" class="form-label">제목</label>
@@ -71,18 +71,39 @@
 
                                     <div class="col-12 mt-3">
                                         <div class="d-flex justify-content-end">
-                                            <button id="completePostBtn" type="submit"
-                                                class="btn btn-primary btn-block">게시물 작성</button>
+                                            <button id="save_post_button" type="button"
+                                                class="btn btn-outline-primary me-2">저장</button>
+                                            <button id="cancel_post_button" type="button"
+                                                class="btn btn-outline-secondary me-2">취소</button>
+                                            <button type="button" class="btn btn-outline-danger me-2"
+                                                data-bs-toggle="modal" data-bs-target="#deleteModal">삭제</button>
                                         </div>
                                     </div>
-
                                 </form>
                             </div>
                         </div>
                     </div>
                 </div>
             </section>
-
+            </div>
+            <!-- 삭제 확인 모달 -->
+            <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel"
+                aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="deleteModalLabel">게시글 삭제 확인</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            정말로 이 게시글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                            <button id = "realDeleteBtn" type="button" class="btn btn-danger">삭제</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </main><!-- End #main -->
 
@@ -108,7 +129,7 @@
             <!-- <script src="../../../assets/js/image-resize.min.js"></script> -->
 
             <!-- Client JS File -->
-            <script defer src="../../../assets/js/post/post-recruit/writePost.js"></script>
+            <script defer src="../../../assets/js/post/post-recruit/editPost.js"></script>
             </body>
 
             </html>

--- a/app/src/views/ejs-file/post/post-recruit/view-post.ejs
+++ b/app/src/views/ejs-file/post/post-recruit/view-post.ejs
@@ -1,6 +1,5 @@
-<!-- 헤더 include -->
-<%- include ('../../partials/header.ejs') %>
-    <%- include ('../../partials/sidebar.ejs') %>
+<%- include('../../partials/header.ejs') %>
+    <%- include('../../partials/sidebar.ejs') %>
 
         <main id="main" class="main">
             <div class="pagetitle">
@@ -14,65 +13,86 @@
             </div><!-- End Page Title -->
 
             <div class="container">
-                <div class="row">
+                <div class="row justify-content-center">
                     <div class="col-lg-12">
                         <section id="post-details" class="mb-5">
                             <div class="card">
                                 <div class="card-body">
-                                    <!-- <div id="post_club_name_title" class="text-uppercase custom-heading" style="font-size: 1.5rem;"></div> -->
-                                    <div class="row">
-                                        <div class="col-12">
-                                            <div id="post_club_info" class="custom-heading" style="font-size: 1.5rem;">
-                                                <span id="post_club_name" class="d-block mb-2"
-                                                    style="color: #007bff; font-weight: bold;"></span>
-                                                <span id="post_title" class="d-block"></span>
+                                    <div class="custom-heading px-3 py-4 bg-light">
+                                        <div class="row">
+                                            <div class="col-md-8">
+                                                <span id="post_club_name"
+                                                    class="d-block mb-2 text-primary font-weight-bold"></span>
+                                                <span id="post_title" class="d-block mb-3 font-weight-normal"
+                                                    style="font-size: 1.25rem;"></span>
+                                                <span id="post_writer" class="d-block mb-3 text-muted"></span>
+                                            </div>
+                                            <div class="col-md-4 text-md-end">
+                                                <button id="edit_post_button" type="button"
+                                                    class="btn btn-sm btn-outline-success me-2"
+                                                    style="display: none;">편집</button>
+                                                <button id="delete_post_button" type="button"
+                                                    class="btn btn-sm btn-outline-danger" data-bs-toggle="modal"
+                                                    data-bs-target="#deleteModal" style="display: none;">삭제</button>
                                             </div>
                                         </div>
                                     </div>
 
-
                                     <hr>
-                                    <div class="row">
-                                        <div class="col-md-4">
-                                            <div class="card">
-                                                <div class="card-body">
-                                                    <p class="card-text"><strong>모집 인원:</strong> <span
-                                                            id="post_recruitment_count"></span></p>
+                                    <div class="container mt-4">
+                                        <div class="row text-center">
+                                            <div class="col-md-4 mb-3">
+                                                <div class="card border-primary">
+                                                    <div class="card-header bg-primary text-white">
+                                                        모집 인원
+                                                    </div>
+                                                    <div class="card-body">
+                                                        <h5 class="card-title" id="post_recruitment_count"></h5>
+                                                    </div>
                                                 </div>
                                             </div>
-                                        </div>
-                                        <div class="col-md-4">
-                                            <div class="card">
-                                                <div class="card-body">
-                                                    <p class="card-text"><strong>게시글 작성일:</strong> <span
-                                                            id="post_created_at"></span></p>
+
+                                            <div class="col-md-4 mb-3">
+                                                <div class="card border-success">
+                                                    <div class="card-header bg-success text-white">
+                                                        게시글 작성일
+                                                    </div>
+                                                    <div class="card-body">
+                                                        <h5 class="card-title" id="post_created_at"></h5>
+                                                    </div>
                                                 </div>
                                             </div>
-                                        </div>
-                                        <div class="col-md-4">
-                                            <div class="card">
-                                                <div class="card-body">
-                                                    <p class="card-text"><strong>모집 마감일:</strong> <span
-                                                            id="post_deadline"></span></p>
+
+                                            <div class="col-md-4 mb-3">
+                                                <div class="card border-danger">
+                                                    <div class="card-header bg-danger text-white">
+                                                        모집 마감일
+                                                    </div>
+                                                    <div class="card-body">
+                                                        <h5 class="card-title" id="post_deadline"></h5>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                     <hr>
-                                    <div id="post_club_content" class="card-text">
+                                    <div id="post_club_content" class="card-text mt-4">
                                         <!-- 게시글 내용 -->
                                     </div>
                                 </div>
                             </div>
                         </section>
 
-
                         <section id="comments" class="mb-5">
                             <div class="card">
                                 <div class="card-body">
                                     <h2 class="mb-4">댓글</h2>
-                                    <form>
-                                        <!-- 댓글 작성 폼 -->
+                                    <form id="comment_form">
+                                        <div class="mb-3">
+                                            <textarea class="form-control" id="comment_input" rows="3"
+                                                placeholder="댓글을 입력하세요..." style="resize: none;"></textarea>
+                                        </div>
+                                        <button class="btn btn-primary">댓글 달기</button>
                                     </form>
                                     <div class="comments-list">
                                         <!-- 댓글 목록 -->
@@ -83,8 +103,27 @@
                     </div>
                 </div>
             </div>
-        </main>
 
+            <!-- 삭제 확인 모달 -->
+            <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel"
+                aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="deleteModalLabel">게시글 삭제 확인</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            정말로 이 게시글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                            <button id="realDeleteBtn" type="button" class="btn btn-danger">삭제</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
 
         <!-- ======= Footer ======= -->
         <%- include ('../../partials/footer.ejs') %>
@@ -101,7 +140,6 @@
             <script src="assets/vendor/quill/quill.min.js"></script>
             <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
             <script src="assets/vendor/simple-datatables/simple-datatables.js"></script>
-            <script src="assets/vendor/tinymce/tinymce.min.js"></script>
             <script src="assets/vendor/php-email-form/validate.js"></script>
 
             <!-- Template Main JS File -->
@@ -109,7 +147,5 @@
 
             <!-- Client JS File -->
             <script defer src="../../../assets/js/post/post-recruit/viewPost.js"></script>
-
             </body>
-
             </ejs>


### PR DESCRIPTION
게시판 편집 기능 스팩 정리

1. 이전에는 작성자가 게시글 작성후 작성된 게시글을 보여주는 페이지와
메인 대시보드에서 클릭해서 들어가는 화면이 달랐는데 통일화 시켰음.
=> 자동으로 게시글을 작성하면 GET 매서드로 지금 작성된 게시글의 페이지를 보여줌.


2. 지금 로그인한 사용자가 작성된 게시글을 들어가서 해당 게시글이 작성된 동아리의 권한자 라면,
즉, 권한자란 이하와 같다. (이후에 나오는 권한자는 이하의 조건을 통과한사람이다.)

club_member테이블의 게시글 동아리의 category의 admin_ac 권한이 있거나, 
club 테이블에 catagory와 로그인 한사람이 일치 한다면 
편집 및 삭제 버튼이 보여진다.


3. 비로그인자 또는 해당 게시글의 동아리의 권한자가 아니라면 편집 및 삭제 버튼이 안보인다.


4. 모든 URL 접근은 권한을 모두 체크하는 상태. url로 접근 한다고해서 다른 동아리 게시글이 편집이 가능하거나 
하지않는다.


5. 권한자가 편집을 하고 저장버튼을 누르면 해당 post_number 행으로 가서 안에 내용을 UPDATE한다.

5-1. 편집 버튼을 누르면 url에 적혀있는 게시글 query로 게시글 테이블을 추적해서 DB에 저장된 내용부터
수정이 가능하다 => 일반 그냥 편집 기능과 동일한 스펙.

5-2. 여기서도 수정중에 "동아리이름"은 로그인한 사람이 권한을 가지고있는 동아리로만 작성이 가능하다.


6. 저장버튼을 누르면 작성된 게시글을 보여주는 페이지로 바로 이동한다.


7. 삭제 버튼도 저장버튼과 동일한 권한자만 보이고 누를수 있음.

7-1. 삭제버튼을 누르면 post_recruit 테이블의 해당 게시글의 post_number에 해당하는 게시글이 DB에서 바로 삭제됌.


8. 취소버튼을 누르면 하던 작업을 모두 취소한다.


9. 작성된 게시글을 보여줄때 가장 마지막에 편집한 사람의 user_id가 보여집니다.


10. 메인화면의 대시보드 게시글 카드와 카드를 클릭해서 자세히 게시글을 보여줄때 ui가 변경되었습니다.


11. 댓글부분 UI도 수정했으나 기능은 아직 넣지 않아서 현재 댓글 버튼을 누르면 서버가 터지니까.
클릭 안하시는게 좋습니다!


#한계:
1. 게시글을 작성 및 편집에서 현재 사진 크기조절이 안되는 상황... 
2. 게시글에 올라오는 사진을 저장할 방법을 골라야함.