### PR TITLE
홍보게시글부터 시작해서 가입신청자가 가입신청을 하는 로직 구현 완료, 동아리 관리자가 받는건 아직 미구현

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -25,6 +25,8 @@ const viewPostRoutes = require('./src/routes/post/postRecruit/view-post.route');
 const indexPostDashboard = require('./src/routes/post/index.postDashboard.route');
 const editPostRoutes = require('./src/routes/post/postRecruit/edit-post.route');
 const recruitCommentRoutes = require('./src/routes/comments/recruit_comments/recruit_comment.route');
+const recruitPostJoinClubRoutes = require('./src/routes/post/postRecruit/join-club/join_club.route');
+const indexClubJoinDashboardRoutes = require('./src/routes/post/postRecruit/join-club/index.clubJoinDashboard.route');
 
 //미들웨어
 app.use(express.json());
@@ -59,6 +61,8 @@ app.use(viewPostRoutes);
 app.use(indexPostDashboard);
 app.use(editPostRoutes);
 app.use(recruitCommentRoutes);
+app.use(recruitPostJoinClubRoutes);
+app.use(indexClubJoinDashboardRoutes);
 
 app.set("view engine", "ejs");
 app.set("views", path.join(__dirname, "src/views/ejs-file"));

--- a/app/src/controllers/comments/recruit_comments/recruit_comment.ctrl.js
+++ b/app/src/controllers/comments/recruit_comments/recruit_comment.ctrl.js
@@ -85,7 +85,7 @@ const updateComment = async (req, res) => {
             [commentData.originalContent, commentData.commentId],
             (err, result) => {
                 if (err) {
-                    handleDBError(`댓글을 삭제 처리할때 에러 발생: ${err}`);
+                    handleDBError(`댓글을 업데이트 할때 에러 발생: ${err}`);
                     resData.success = false;
                     return res.json(resData);
                 }
@@ -179,4 +179,5 @@ module.exports = {
     updateComment,
     addReplyComment,
     getClubOwnerId,
+    getCategoryQuery,
 }

--- a/app/src/controllers/postCtrollers/postRecruitControllers/editPost.ctrl.js
+++ b/app/src/controllers/postCtrollers/postRecruitControllers/editPost.ctrl.js
@@ -96,6 +96,10 @@ async function getPostCategory(post_number) {
                     handleDBError(err);
                     return reject(err);
                 }
+                if (result.length === 0) {
+                    const error = new Error('No category found for the specified post number.');
+                    return reject(error);
+                }
                 resolve(result[0].category);
             }
         )
@@ -130,7 +134,7 @@ async function isPostAdminAc(category, userId) {
                     handleDBError(err);
                     return reject(err);
                 }
-                if (result.length === 0) {
+                if (result.length === 0 || result[0].admin_ac === 0) {
                     resolve(false);
                 } else {
                     resolve(true);

--- a/app/src/controllers/postCtrollers/postRecruitControllers/joinClubControllers/index.clubJoinDashboard.ctrl.js
+++ b/app/src/controllers/postCtrollers/postRecruitControllers/joinClubControllers/index.clubJoinDashboard.ctrl.js
@@ -1,0 +1,69 @@
+const { executeQuery, executeQueryPromise } = require("../../../../config/database.func");
+const { handleDBError } = require("../../../../controllers/login.ctrl");
+const { getTokenDecode } = require("../../../tokenControllers/token.ctrl");
+
+async function getClubData(category) {
+    const query = `SELECT * FROM club WHERE category = ?;`;
+    try {
+        const result = await executeQueryPromise(query, [category]);
+        return result[0];
+    } catch (error) {
+        handleDBError(`카테고리로 클럽데이터 조회중 오류 발생: ${error}`);
+    }
+}
+
+const getClubApplicationsListForIndex = async (req, res) => {
+    const resData = { success: false, clubApplicationData: [] };
+    try {
+        const decodedToken = await getTokenDecode(req, res);
+        const query = `SELECT * FROM club_applications WHERE user_id = ?;`;
+
+        const result = await executeQueryPromise(query, [decodedToken.id]);
+        if (result.length === 0) {
+            resData.success = false;
+            return res.json(resData);
+        }
+        resData.success = true;
+
+        for (let idx = 0; idx < result.length; idx++) {
+            const clubData = await getClubData(result[idx].category);
+            const applicationDate = new Date(result[idx].application_date).toISOString().split('T')[0]; // ISO 문자열에서 날짜 부분만 추출
+            const clubApplicationInfo = {
+                application_id: result[idx].application_id,
+                club_name: clubData.club_name,
+                club_owner: clubData.club_owner,
+                create_day: applicationDate, // 날짜 형식 변경
+                status: result[idx].application_status,
+            };
+            resData.clubApplicationData.push(clubApplicationInfo);
+        }
+        res.json(resData);
+    } catch (error) {
+        handleDBError(`가입 신청중인 목록 가져오는중 에러 발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const cancelApplication = (req, res) => {
+    const resData = {};
+    const { applicationId } = req.body;
+    const query = `DELETE FROM club_applications WHERE application_id = ?;`;
+
+    executeQuery(query, [applicationId],
+        (err, result) => {
+            if (err) {
+                handleDBError(`클럽 신청서 취소중 쿼리에서 에러 발생: ${err}`);
+                resData.success = false;
+                res.status(500).json(resData);
+                return;
+            }
+            resData.success = true;
+            res.json(resData);
+        })
+}
+
+module.exports = {
+    getClubApplicationsListForIndex,
+    cancelApplication,
+}

--- a/app/src/controllers/postCtrollers/postRecruitControllers/joinClubControllers/joinClub.ctrl.js
+++ b/app/src/controllers/postCtrollers/postRecruitControllers/joinClubControllers/joinClub.ctrl.js
@@ -1,0 +1,97 @@
+const { executeQuery } = require("../../../../config/database.func");
+const { handleDBError } = require("../../../../controllers/login.ctrl");
+const { getTokenDecode } = require("../../../tokenControllers/token.ctrl");
+const { getCategoryQuery } = require("../../../comments/recruit_comments/recruit_comment.ctrl");
+
+const isJoinedThisClub = async (req, res) => {
+    const resData = {};
+    try {
+        const postNum = req.query.query;
+        const decodedToken = await getTokenDecode(req, res);
+
+        const query = `SELECT * FROM club_member
+                        WHERE category = (
+                            SELECT category FROM post_recruit
+                            WHERE post_number = ?
+                        ) AND member_student_id = ?;
+                        `;
+
+        executeQuery(query, [postNum, decodedToken.studentId],
+            (err, result) => {
+                if (err) {
+                    handleDBError(`해당 동아리에 가입여부를 확인중 에러 발생: ${err}`);
+                    resData.success = false;
+                    resData.canJoinUser = false;
+                    return res.json(resData);
+                }
+                if (result.length !== 0) {
+                    resData.success = true;
+                    resData.canJoinUser = false;
+                    return res.json(resData);
+                }
+                resData.success = true;
+                resData.canJoinUser = true;
+                return res.json(resData);
+            })
+    } catch (error) {
+        console.error(`해당 동아리에 가입여부를 확인중 에러 발생: ${error}`);
+        resData.success = false;
+        resData.canJoinUser = false;
+        res.status(500).json(resData);
+    }
+}
+
+const getMemberData = async (req, res) => {
+    const resData = {};
+    try {
+        const decodedToken = await getTokenDecode(req, res);
+        
+        executeQuery('SELECT user_id, user_name, user_student_id, user_department, user_ph_number FROM member WHERE user_id = ?',
+        [decodedToken.id],
+        (err, result) => {
+            if(err){
+                handleDBError(`유저 정보를 가져오는중 에러 발생: ${err}`);
+                resData.success = false;
+                return res.json(resData);
+            }
+            resData.success = true;
+            resData.userData = result[0];
+            res.json(resData);
+        }
+    )
+    } catch (error) {
+        console.error(`유저 정보를 가져오는중 에러 발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const setClubApplication = async (req, res) => {
+    const resData = {};
+    try {
+        const clubApplicationData = req.body;
+        const category = await getCategoryQuery(clubApplicationData.postNum);
+
+        const query = `INSERT INTO club_applications (user_id, category, gender, residence, introduction) VALUES (?, ?, ?, ?, ?)`;
+        executeQuery(query, [clubApplicationData.user_id, category.category, clubApplicationData.gender, clubApplicationData.residence, clubApplicationData.introduction],
+        (err, result) => {
+            if(err){
+                handleDBError(`클럽 신청서를 DB에 넣다가 에러 발생: ${err}`);
+                resData.success = false;
+                return res.json(resData);
+            }
+            resData.success = true;
+            return res.json(resData);
+        })
+    } catch (error) {
+        console.error("클럽 신청서 작성 실패", error);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+module.exports = {
+    isJoinedThisClub,
+    getMemberData,
+    setClubApplication,
+}

--- a/app/src/routes/post/postRecruit/join-club/index.clubJoinDashboard.route.js
+++ b/app/src/routes/post/postRecruit/join-club/index.clubJoinDashboard.route.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const { getClubApplicationsListForIndex, cancelApplication } = require('../../../../controllers/postCtrollers/postRecruitControllers/joinClubControllers/index.clubJoinDashboard.ctrl');
+
+router.get('/api/clubApplications/list/get', getClubApplicationsListForIndex);
+
+router.delete('/api/clubApplications/list/Cancel', cancelApplication)
+
+module.exports = router;

--- a/app/src/routes/post/postRecruit/join-club/join_club.route.js
+++ b/app/src/routes/post/postRecruit/join-club/join_club.route.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+const { isJoinedThisClub, getMemberData, setClubApplication } = require('../../../../controllers/postCtrollers/postRecruitControllers/joinClubControllers/joinClub.ctrl');
+
+router.get('/api/check/JoinedThisClub', isJoinedThisClub);
+
+router.get('/api/join_club/memberData/get', getMemberData);
+
+router.post('/api/join_club/applications/post', setClubApplication);
+
+module.exports = router;

--- a/app/src/views/assets/css/style.css
+++ b/app/src/views/assets/css/style.css
@@ -1268,3 +1268,65 @@ h6 {
   animation: colorChange 2s linear 0s 1; /* 2초 동안 애니메이션 실행, 선형 속도, 0초 지연, 1회 반복 */
 }
 /* 로그인창 CSS 끝*/
+
+/* 메인 화면(대시보드)에서 뿌려주는 동아리 신청현황 테이블 css */
+.dataTables_wrapper {
+  width: 100%;
+  margin: auto;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  padding: 20px;
+  border-radius: 10px;
+  background-color: #ffffff;
+}
+
+.dataTables_filter input {
+  height: 38px;
+  border: 1px solid #DDD;
+  padding: 0 15px;
+  border-radius: 20px;
+  margin-left: 5px;
+}
+
+.dataTables_paginate .paginate_button {
+  padding: 5px 10px;
+  margin: 0 2px;
+  border: 1px solid #DDD;
+  border-radius: 5px;
+  cursor: pointer;
+  color: #666;
+}
+
+.dataTables_paginate .paginate_button:hover {
+  background-color: #EEE;
+  border-color: #BBB;
+}
+
+.dataTables_paginate .paginate_button.current, .dataTables_paginate .paginate_button.current:hover {
+  color: #FFF;
+  background-color: #007bff;
+  border-color: #007bff;
+}
+.dataTables_wrapper .dataTables_processing {
+  background: #f4f4f4;
+  border: 1px solid #ddd;
+  padding: 5px;
+  border-radius: 3px;
+  box-shadow: 0 2px 3px rgba(0,0,0,0.1);
+}
+
+table.dataTable thead th {
+  border-bottom: 2px solid #ddd;
+}
+
+table.dataTable tbody td {
+  border-bottom: 1px solid #ddd;
+}
+
+table.dataTable thead .sorting_asc:after {
+  content: "\2191"; /* 위쪽 화살표 */
+}
+
+table.dataTable thead .sorting_desc:after {
+  content: "\2193"; /* 아래쪽 화살표 */
+}
+/* 메인 화면(대시보드) 동아리 신청 현황 테이블 css 끝 */

--- a/app/src/views/assets/js/post/post-recruit/join_club/index.clubJoinDashboard.js
+++ b/app/src/views/assets/js/post/post-recruit/join_club/index.clubJoinDashboard.js
@@ -1,0 +1,222 @@
+// 로그인 상태 확인 함수
+async function checkLogin() {
+    try {
+        const response = await fetch('/isLogin', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        if (!response.ok) {
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        return data;
+    } catch (err) {
+        handleLoginError(err);
+    }
+}
+
+// 가입신청 목록 가져오는 함수
+async function getClubJoinApplications() {
+    try {
+        const response = await fetch('/api/clubApplications/list/get', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        if (!response.ok) {
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        return data.clubApplicationData;
+    } catch (error) {
+        handleClubApplicationsError(error);
+    }
+}
+
+// 동아리 가입신청 목록을 테이블에 채우는 함수
+function fillClubApplicationsTable(clubApplications) {
+    const tableContainer = document.getElementById('clubApplicationsTable');
+    tableContainer.innerHTML = ''; // 기존 테이블 삭제
+
+    if (clubApplications.length === 0) {
+        displayNoClubApplicationsMessage();
+    } else {
+        displayClubApplicationsTable(clubApplications);
+    }
+}
+
+// 상태에 따라 배지 스타일을 지정하는 함수
+function getStatusBadgeClass(status) {
+    switch (status) {
+        case '대기 중':
+            return 'bg-warning';
+        case '승인됨':
+            return 'bg-success';
+        case '거절됨':
+            return 'bg-danger';
+        default:
+            return 'bg-secondary';
+    }
+}
+
+// 로그인 에러 처리 함수
+function handleLoginError(err) {
+    alert("에러가 발생했습니다.");
+    console.error(err);
+    window.location.href = "/";
+}
+
+// 가입신청 목록 에러 처리 함수
+function handleClubApplicationsError(error) {
+    alert(`가입신청중인 동아리 목록을 가져오는데 실패했습니다. ${error}`);
+    console.error("가입신청중인 동아리 목록을 가져오는데 실패했습니다.", error);
+    window.location.reload();
+}
+
+// 가입신청이 없는 경우 메시지 표시 함수
+async function displayNoClubApplicationsMessage() {
+    const tableContainer = document.getElementById('clubApplicationsTable');
+    const noApplicationsMessage = document.createElement('div');
+    noApplicationsMessage.classList.add('alert', 'alert-info');
+    noApplicationsMessage.textContent = '가입할 동아리가 없으시군요! 관심 있는 동아리를 찾아보고 지금 바로 가입하세요.';
+    tableContainer.appendChild(noApplicationsMessage);
+
+    // 로그인 상태에 따라 메시지 표시
+    const isLogin = await checkLogin();
+    if (!isLogin.isLogin) {
+        displayLoginPromptMessage(tableContainer);
+        return;
+    }
+}
+
+// 로그인 프롬프트 메시지 표시 함수
+function displayLoginPromptMessage(container) {
+    const loginPromptMessage = document.createElement('div');
+    loginPromptMessage.classList.add('alert', 'alert-info', 'mt-3');
+    loginPromptMessage.innerHTML = `
+        <p>동아리에 가입하려면 먼저 <a href="/pages-login">로그인</a>해주세요.</p>
+    `;
+    container.appendChild(loginPromptMessage);
+}
+
+function displayClubApplicationsTable(clubApplications) {
+    const tableContainer = document.getElementById('clubApplicationsTable');
+    tableContainer.innerHTML = ''; // 이전 테이블 내용을 비웁니다.
+
+    const table = document.createElement('table');
+    table.classList.add('table', 'table-striped', 'datatable'); // 부트스트랩 클래스 추가
+
+    const tableHeader = document.createElement('thead');
+    tableHeader.innerHTML = `
+        <tr>
+            <th scope="col">#</th>
+            <th scope="col">동아리 이름</th> 
+            <th scope="col">동아리 대표</th> 
+            <th scope="col">신청 날짜</th>
+            <th scope="col">상태</th>
+            <th scope="col">취소</th>
+        </tr>
+    `;
+    table.appendChild(tableHeader);
+
+    const tableBody = document.createElement('tbody');
+    clubApplications.forEach((application, index) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <th scope="row">${application.application_id}</th>
+            <td>${application.club_name}</td>
+            <td>${application.club_owner}</td>
+            <td>${application.create_day}</td>
+            <td><span class="badge ${getStatusBadgeClass(application.status)}">${application.status}</span></td>
+            <td>
+                ${application.status === '대기 중' ? `<button type="button" class="btn btn-danger btn-sm" onclick="displayCancelApplicationModal(${application.application_id})">취소</button>` : ''}
+            </td>
+        `;
+        tableBody.appendChild(row);
+    });
+    table.appendChild(tableBody);
+
+    tableContainer.appendChild(table);
+
+    // DataTables 적용
+    $(table).DataTable({
+        // DataTables 설정을 여기에 추가합니다.
+        language: {
+            url: "https://cdn.datatables.net/plug-ins/1.10.24/i18n/Korean.json"
+        },
+        pageLength: 5, // 기본 페이지당 표시되는 행의 수를 10으로 설정합니다.
+        lengthMenu: [[5, 10, 15], [5, 10, 15]], // 사용자가 선택할 수 있는 페이지당 행의 수를 [5, 10, 15]로 설정합니다.
+        order: [[0, 'desc']], // 첫 번째 열을 기준으로 내림차순 정렬합니다. 
+    });
+}
+
+// 동아리 신청 취소 모달 띄우기.
+function displayCancelApplicationModal(applicationId) {
+    const modal = new bootstrap.Modal(document.getElementById('clubApplicationCancelModal'), {
+        keyboard: false
+    });
+    const confirmBtn = document.getElementById('clubApplicationConfirmCancelBtn');
+    confirmBtn.addEventListener('click', function() {
+        cancelApplicationFetch(applicationId);
+    });
+    modal.show();
+}
+
+function cancelApplicationFetch(applicationId){
+    fetch('/api/clubApplications/list/Cancel',{
+        method: 'DELETE',
+        body: JSON.stringify({applicationId}),
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+    .then(res => {
+        if(!res.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        return res.json();
+    })
+    .then(data => {
+        if(!data.success){
+            throw new Error('동아리 신청 취소에 실패하였습니다.');
+        }
+        alert(`${applicationId}번 신청서에 대해서 취소하였습니다.`);
+        window.location.reload();
+    })
+    .catch(err => {
+        alert(`${applicationId}번 동아리 신청 취소중 에러가 발생했습니다.`);
+        console.error(err);
+    })
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const isLogin = await checkLogin();
+    if (!isLogin.isLogin) {
+        fillClubApplicationsTable([]);
+    } else {
+        const clubAppData = await getClubJoinApplications();
+        fillClubApplicationsTable(clubAppData);
+    }
+
+    // 목록 접기/펼치기 버튼 이벤트 리스너 추가
+    const toggleButton = document.getElementById('toggleButton');
+    const tableContainer = document.getElementById('clubApplicationsTable');
+
+    // 버튼 클릭 이벤트 리스너
+    toggleButton.addEventListener('click', function() {
+        if (tableContainer.classList.contains('show')) {
+            // 목록이 펼쳐져 있는 경우
+            tableContainer.classList.remove('show'); // 목록을 접음
+            toggleButton.getElementsByClassName('buttonText')[0].textContent = '신청중인 동아리 목록 펼치기';
+            toggleButton.getElementsByClassName('bi')[0].className = 'bi bi-chevron-down';
+        } else {
+            // 목록이 접혀 있는 경우
+            tableContainer.classList.add('show'); // 목록을 펼침
+            toggleButton.getElementsByClassName('buttonText')[0].textContent = '신청중인 동아리 목록 접기';
+            toggleButton.getElementsByClassName('bi')[0].className = 'bi bi-chevron-up';
+        }
+    });
+});

--- a/app/src/views/assets/js/post/post-recruit/join_club/join_club.js
+++ b/app/src/views/assets/js/post/post-recruit/join_club/join_club.js
@@ -1,0 +1,151 @@
+function getPostNumber() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const postNum = urlParams.get('query');
+    return postNum;
+}
+
+async function checkLogin() {
+    try {
+        const response = await fetch('/isLogin', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        if (!response.ok) {
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        return data;
+    } catch (err) {
+        alert("에러가 발생했습니다.");
+        console.error(err);
+        window.location.href = "/";
+    }
+}
+
+document.getElementById('joinClubBtn').addEventListener('click', async (event) => {
+    event.preventDefault();
+
+    const isUserLoggedIn = await checkLogin();
+    if (!isUserLoggedIn.isLogin) {
+        return window.location.href = "/pages-login";
+    }
+    const isJoinedClub = await isJoinedThisClub();
+    if(!isJoinedClub){
+        return;
+    }
+    getMemberData();
+});
+
+function setJoinClubModal(joinClubUserData){
+        document.getElementById('nameInput').innerText = joinClubUserData.user_name;
+        document.getElementById('emailInput').innerText = joinClubUserData.user_id;
+        document.getElementById('studentIdInput').innerText = joinClubUserData.user_student_id;
+        document.getElementById('departmentInput').innerText = joinClubUserData.user_department;
+        document.getElementById('phoneInput').innerText = joinClubUserData.user_ph_number;
+        
+        const joinClubModal = document.getElementById('clubJoinApplicationModal');
+        const joinClubModalInstance = new bootstrap.Modal(joinClubModal);
+        joinClubModalInstance.show();
+}
+
+// "가입신청" 버튼 클릭 시 실행되는 함수
+document.getElementById("clubJoinApplicationForm").addEventListener("submit", function(event) {
+    event.preventDefault();
+    const userJoinClubData = {};
+
+    userJoinClubData.postNum = getPostNumber();
+    userJoinClubData.user_id = document.getElementById('emailInput').innerText;
+    userJoinClubData.gender = document.getElementById("genderInput").value;
+    userJoinClubData.residence = document.getElementById("residenceInput").value;
+    userJoinClubData.introduction = document.getElementById("introductionInput").value;
+
+    fetch(`/api/join_club/applications/post`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(userJoinClubData),
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error("네트워크 응답이 올바르지 않습니다.");
+        }
+        return response.json();
+    })
+    .then(data => {
+        if(!data.success){
+            alert('신청서를 제출에 실패하였습니다.');
+            window.location.reload();
+            return;
+        }
+        alert(`신청서 제출에 성공하였습니다!`);
+        window.location.reload();
+    })
+    .catch(error => {
+        alert(`클럽 가입 신청서를 작성중에 에러가 발생했습니다. ${error}`);
+        console.error("클럽 가입 신청서를 작성중에 에러가 발생했습니다.", error);
+        window.location.reload();
+    });
+});
+
+function getMemberData(){
+    fetch('/api/join_club/memberData/get', {
+        method: 'GET',
+        headers:{
+            'Content-Type': 'application/json',
+        },
+    })
+    .then(res => {
+        if(!res.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        return res.json();
+    })
+    .then(data => {
+        if(!data.success){
+            alert('유저 정보를 가져오지 못했습니다.');
+            window.location.reload();
+            return;
+        }
+        setJoinClubModal(data.userData);
+    })
+    .catch(err => {
+        alert(`에러발생: ${err}`);
+        window.location.href = "/";
+    })
+}
+
+//동아리에 가입 가능한 유저인지 확인.
+//해당동아리에 가입이 되어있는지?
+async function isJoinedThisClub() {
+    try {
+        const postNum = getPostNumber();
+        const res = await fetch(`/api/check/JoinedThisClub?query=${postNum}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!res.ok) {
+            throw new Error('유저의 클럽가입 여부를 확인중 에러 발생.');
+        }
+        const data = await res.json();
+        if (!data.success) {
+            alert('유저 정보 조회를 실패하였습니다.');
+            window.location.reload();
+            return false;
+        }
+        if (!data.canJoinUser) {
+            alert('이미 가입된 동아리 입니다.');
+            return false;
+        }
+        return true;
+    } catch (error) {
+        alert('클럽 가입여부를 확인중 에러가 발생했습니다.');
+        console.error(`에러발생 ${error}`);
+        window.location.reload();
+    }
+}

--- a/app/src/views/assets/js/post/post-recruit/viewPost.js
+++ b/app/src/views/assets/js/post/post-recruit/viewPost.js
@@ -22,6 +22,20 @@ function setViewPostingInfo(postData) {
     // Quill Delta를 HTML로 변환하여 설정
     let htmlContent = quillGetHTML(postData.content);
     document.getElementById('post_club_content').innerHTML = htmlContent;
+
+    // deadline이 지났는지 확인하고 알림 표시
+    const now = new Date();
+    const deadline = new Date(postData.dead_day);
+    if (now > deadline) {
+        const alertDiv = document.createElement('div');
+        alertDiv.classList.add('alert', 'alert-danger', 'bg-danger', 'text-light', 'border-0', 'alert-dismissible', 'fade', 'show');
+        alertDiv.setAttribute('role', 'alert');
+        alertDiv.innerHTML = '해당 동아리 게시글은 마감되었습니다.';
+        document.getElementById('post_deadline_alert').appendChild(alertDiv);
+        
+        const joinClubBtn = document.getElementById('joinClubBtn');
+        joinClubBtn.disabled = true;
+    }
 }
 
 function quillGetHTML(inputDelta) {

--- a/app/src/views/ejs-file/index.ejs
+++ b/app/src/views/ejs-file/index.ejs
@@ -4,7 +4,6 @@
   <%- include ('partials/sidebar.ejs') %>
 
     <main id="main" class="main">
-
       <div class="pagetitle">
         <h1>Dashboard</h1>
         <nav>
@@ -14,6 +13,15 @@
           </ol>
         </nav>
       </div><!-- End Page Title -->
+
+      <!-- 신청 중인 동아리 목록 섹션 -->
+      <div id="clubApplicationsSection" class="mt-3">
+        <button id="toggleButton" class="btn btn-primary">
+          <span class="buttonText">신청중인 동아리 목록 접기</span> <!-- 수정된 텍스트 -->
+          <i class="bi bi-chevron-up"></i> <!-- 수정된 아이콘 -->
+        </button>
+        <div id="clubApplicationsTable" class="collapse show"></div>
+      </div>
 
       <section class="section dashboard">
         <div class="row">
@@ -28,60 +36,30 @@
               </div>
               <div id="card-container" class="row row-cols-1 row-cols-md-3 g-4">
               </div>
-
-              <!-- 테이블 -->
-              <!-- <div class="col-md-4">
-                <table class="table">
-                  <thead>
-                    <tr>
-                      <th scope="col"></th>
-                      <th scope="col">동아리 이름</th>
-                      <th scope="col">모집여부</th>
-                      <th scope="col">모집인원</th>
-                      <th scope="col">마감일</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th scope="row">1</th>
-                      <td>동아리</td>
-                      <td>모집중</td>
-                      <td>5</td>
-                      <td>2024-03-25</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">2</th>
-                      <td>동아리</td>
-                      <td>모집중</td>
-                      <td>5</td>
-                      <td>2024-03-25</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">3</th>
-                      <td>동아리</td>
-                      <td>모집중</td>
-                      <td>5</td>
-                      <td>2024-03-25</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">4</th>
-                      <td>동아리</td>
-                      <td>모집중</td>
-                      <td>5</td>
-                      <td>2024-03-25</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">5</th>
-                      <td>동아리</td>
-                      <td>모집중</td>
-                      <td>5</td>
-                      <td>2024-03-25</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div> -->
             </div>
+          </div>
+        </div>
       </section>
+
+      <!-- 동아리 신청 취소 확인 모달 -->
+      <div class="modal fade" id="clubApplicationCancelModal" tabindex="-1"
+        aria-labelledby="clubApplicationCancelModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="clubApplicationCancelModalLabel">동아리 신청 취소 확인</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              정말로 이 동아리 신청을 취소하시겠습니까?<br>해당 신청서는 동아리에서 심사중입니다.
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+              <button id="clubApplicationConfirmCancelBtn" type="button" class="btn btn-danger"
+                data-bs-dismiss="modal">취소 확인</button>
+            </div>
+          </div>
+        </div>
       </div>
 
     </main><!-- End #main -->
@@ -104,12 +82,16 @@
       <script src="assets/vendor/tinymce/tinymce.min.js"></script>
       <script src="assets/vendor/php-email-form/validate.js"></script>
 
+      <!--신청중인 테이블을 보여주기 위한 jquery 설정-->
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+      <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
 
       <!-- Template Main JS File -->
       <script src="assets/js/main.js"></script>
 
       <!-- Client JS File -->
       <script defer src="../assets/js/post/index.postDashboard.js"></script>
+      <script defet src="../assets/js/post/post-recruit/join_club/index.clubJoinDashboard.js"></script>
 
       </body>
 

--- a/app/src/views/ejs-file/post/post-recruit/view-post.ejs
+++ b/app/src/views/ejs-file/post/post-recruit/view-post.ejs
@@ -15,6 +15,7 @@
             <div class="container">
                 <div class="row justify-content-center">
                     <div class="col-lg-12">
+                        <div id="post_deadline_alert"></div>
                         <section id="post-details" class="mb-5">
                             <div class="card">
                                 <div class="card-body">
@@ -79,6 +80,12 @@
                                     <div id="post_club_content" class="card-text mt-4">
                                         <!-- 게시글 내용 -->
                                     </div>
+                                    <hr>
+                                    <!-- 동아리 신청하기 버튼 -->
+                                    <div class="text-center mt-4">
+                                        <button type="button" id="joinClubBtn"
+                                            class="btn btn-lg btn-success shadow-lg">동아리 가입 신청하기</button>
+                                    </div>
                                 </div>
                             </div>
                         </section>
@@ -127,7 +134,8 @@
             </div>
 
             <!-- 댓글 편집 모달 -->
-            <div class="modal fade" id="commentEditModal" tabindex="-1" aria-labelledby="commentEditModalLabel" aria-hidden="true">
+            <div class="modal fade" id="commentEditModal" tabindex="-1" aria-labelledby="commentEditModalLabel"
+                aria-hidden="true">
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
@@ -166,6 +174,89 @@
                 </div>
             </div>
 
+            <div class="modal fade" id="clubJoinApplicationModal" tabindex="-1"
+                aria-labelledby="clubJoinApplicationModalLabel" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered">
+                    <div class="modal-content">
+                        <div class="modal-header bg-primary text-white">
+                            <h5 class="modal-title" id="clubJoinApplicationModalLabel">클럽 가입 신청서
+                                <span class="info-icon" data-bs-toggle="tooltip" data-bs-placement="top"
+                                    title="기본적인 정보는 가입시에 기입했던 내용이 들어갑니다.">
+                                    <i class="bi bi-question-circle"></i>
+                                </span>
+                            </h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+                                aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <form id="clubJoinApplicationForm" class="was-validated">
+                                <div class="mb-3 row">
+                                    <div class="col">
+                                        <label for="nameInput" class="form-label">이름</label>
+                                        <p class="form-control-static" id="nameInput"></p>
+                                    </div>
+                                    <div class="col">
+                                        <label for="emailInput" class="form-label">Email / ID</label>
+                                        <p class="form-control-static" id="emailInput"></p>
+                                    </div>
+                                    <div class="col">
+                                        <label for="phoneInput" class="form-label">전화번호</label>
+                                        <p class="form-control-static" id="phoneInput"></p>
+                                    </div>
+                                </div>
+                                <div class="mb-3 row">
+                                    <div class="col">
+                                        <label for="studentIdInput" class="form-label">학번</label>
+                                        <p class="form-control-static" id="studentIdInput"></p>
+                                    </div>
+                                    <div class="col">
+                                        <label for="departmentInput" class="form-label">학과</label>
+                                        <p class="form-control-static" id="departmentInput"></p>
+                                    </div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="genderInput" class="form-label">성별</label>
+                                    <select class="form-select" id="genderInput" required>
+                                        <option selected disabled value="">선택하세요</option>
+                                        <option>남성</option>
+                                        <option>여성</option>
+                                    </select>
+                                    <div class="invalid-feedback">성별을 선택하세요.</div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="residenceInput" class="form-label">거주지</label>
+                                    <input type="text" class="form-control" id="residenceInput" required>
+                                    <div class="invalid-feedback">거주지를 입력하세요.</div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="introductionInput" class="form-label">간단한 자기소개</label>
+                                    <textarea class="form-control" id="introductionInput" rows="4" required></textarea>
+                                    <div class="invalid-feedback">자기소개를 입력하세요.</div>
+                                </div>
+                                <div class="mb-3 form-check">
+                                    <input type="checkbox" class="form-check-input" id="understandCheck" required>
+                                    <label class="form-check-label" for="understandCheck">지원하기 전 충분히 해당 게시글의 내용을
+                                        숙지했습니다.</label>
+                                </div>
+                                <div class="mb-3 form-check">
+                                    <input type="checkbox" class="form-check-input" id="infoCheck" required>
+                                    <label class="form-check-label" for="infoCheck">ID, 이름, 학번, 학과, 전화번호와 기입한 내용이 해당 동아리
+                                        관리자에게 전달됩니다.</label>
+                                </div>
+                                <div class="mb-3 form-check">
+                                    <input type="checkbox" class="form-check-input" id="responsibilityCheck" required>
+                                    <label class="form-check-label" for="responsibilityCheck">사실과 다른 내용을 기입하거나, 사이트 용도와
+                                        맞지 않는 내용의 책임은 본인에게 있습니다.</label>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                                    <button id="clubJoinApplicationBtn" type="submit" class="btn btn-primary">가입신청</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </main>
 
         <!-- ======= Footer ======= -->
@@ -191,6 +282,7 @@
             <!-- Client JS File -->
             <script defer src="../../../assets/js/post/post-recruit/viewPost.js"></script>
             <script defer src="../../../assets/js/comments/recruit_comments/recruit_comment.js"></script>
+            <script defer src="../../../assets/js/post/post-recruit/join_club/join_club.js"></script>
 
             </body>
             </ejs>


### PR DESCRIPTION
<홍보게시판에서 동아리 가입 신청하기 스팩>
0. 동아리 가입 신청은 오로지 해당 동아리 홍보 게시글의 하단에 "가입신청" 버튼을 통해서만 가능합니다.

1. 마감된 게시글(deadline이 지난경우)은 상단에 "해당 동아리 게시글은 마감되었습니다." 경고창이 뜨고 게시글 하단에 "동아리 신청하기" 버튼이 비활성화 됩니다.

2. 이하 로직은 하단의 첨부하는 사진과 같습니다.

3. 신청중인 동아리 현황은 메인 대시보드에서 아래 사진과 같이 ui가 보입니다.

4. 신청중인 동아리 테이블은 접기, 펼치기 버튼을 통해 간략화가 가능합니다.

5. 해당 테이블의 검색기능, 페이지당 줄수, 컬럼을 클릭해 오름차순, 내림차순이 모두 가능합니다.

6. 테이블에 취소 버튼은 "대기 중" 상태만 가능하며 "거절됨", "승인됨"의 경우는 취소가 불가능합니다.

7. 아직 동아리 관리자가 승인을 하는 로직은 구현되지 않았습니다. 추후에 동아리 관리 페이지에서 "가입 신청 현황"에서 동아리 관리자가 신청서를 보고 "승인", "거절"의 기능을 만들고 club_member 테이블에 가입시키는 로직을 추가할 예정입니다.
=> 성영님의 작업에 충돌이 있을것 같아서 보류.

8. 새롭게 club_applications 테이블이 추가되었습니다. 해당 테이블은 가입 신청서를 모아두는 테이블입니다. 외래키 및 기타 컬럼은 아래 쿼리문을 확인 바랍니다.

![club_applications 테이블 쿼리](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/cb1ee5b1-4885-4223-b55e-ba19af43cf20)
![동아리 가입 로직](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/b879e003-44fa-4c65-a9d9-6441e41aa27c)
![메인 대시보드의 동아리 신청 현황](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/09a37351-bd00-4922-bb2e-272cceebd50d)
