### PR TITLE
동아리 등록 신청에 대해서 모든 기능 구현 완료.

### DIFF
--- a/app/src/controllers/create-club.ctrl.js
+++ b/app/src/controllers/create-club.ctrl.js
@@ -1,4 +1,4 @@
-const { executeQuery, executeQueryPromise } = require("../config/database.func");
+const { executeQueryPromise } = require("../config/database.func");
 const { handleDBError } = require("../controllers/login.ctrl");
 const { getTokenDecode } = require("../controllers/tokenControllers/token.ctrl");
 
@@ -15,7 +15,7 @@ const setCreateClub = async (req, res) => {
 
         const query = `INSERT INTO club_create_applications (user_id, user_name, club_name, member_count, affilition, user_ph_number, club_content) VALUES (?, ?, ?, ?, ?, ?, ?);`;
         await executeQueryPromise(query, [user_id, user_name, club_name, club_members, affilition, ph_number, club_content]);
-        
+
         resData.success = true;
         res.json(resData);
     } catch (error) {
@@ -33,7 +33,7 @@ const getCreateClubList = async (req, res) => {
         const query = `SELECT * FROM club_create_applications WHERE user_id = ?;`;
         const result = await executeQueryPromise(query, [decodedToken.id]);
 
-        if(result.length === 0){
+        if (result.length === 0) {
             resData.success = true;
             resData.hasClubList = false;
             res.status(200).json(resData);
@@ -52,7 +52,164 @@ const getCreateClubList = async (req, res) => {
     }
 }
 
+const deleteClubApplication = async (req, res) => {
+    const resData = {};
+    try {
+        const { applicationId } = req.body;
+        const query = `DELETE FROM club_create_applications WHERE club_application_id = ?;`;
+
+        const result = await executeQueryPromise(query, [applicationId]);
+
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리 등록 신청을 취소하던중 에러 발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const getCreateClubApplicationListData = async (req, res) => {
+    const resData = {};
+    try {
+        const query = `SELECT * FROM club_create_applications`;
+        const result = await executeQueryPromise(query);
+
+        if (result.length === 0) {
+            resData.success = true;
+            resData.hasClubList = false;
+            res.status(200).json(resData);
+            return;
+        }
+
+        resData.success = true;
+        resData.hasClubList = true;
+        resData.CreateClubList = result;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리 등록 신청 리스트를 가져오던중 에러발생: ${error}`);
+        resData.success = false;
+        resData.hasClubList = false;
+        res.status(500).json(resData);
+    }
+}
+
+//application_id에 해당하는 한개의 row 데이터만 가져옴.
+const getCreateClubApplicationData = async (req, res) => {
+    const resData = {};
+    try {
+        const applicationId = req.body;
+        const query = `SELECT * FROM club_create_applications WHERE club_application_id = ?;`;
+        const result = await executeQueryPromise(query, [applicationId.clubApplicationId]);
+
+        if (result.length === 0) {
+            resData.success = false;
+            res.status(500).json(resData);
+            return;
+        }
+        resData.success = true;
+        resData.CreateClubData = result[0];
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리 등록 신청 세부정보를 가져오던중 에러발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+function formatDate() {
+    const currentDate = new Date();
+    const year = currentDate.getFullYear();
+    const month = String(currentDate.getMonth() + 1).padStart(2, '0');
+    const day = String(currentDate.getDate()).padStart(2, '0');
+    const formattedDate = `${year}-${month}-${day}`;
+    return formattedDate;
+}
+
+const updateStatus = async (req, res) => {
+    const resData = {};
+    try {
+        const date = formatDate();
+        const applicationData = req.body;
+
+        const query = `UPDATE club_create_applications SET application_status = ?, processed_date = ? WHERE club_application_id = ?;`;
+        const result = await executeQueryPromise(query, [applicationData.status, date, applicationData.applicationId]);
+        
+        await addClub(applicationData);
+        
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리 등록 신청의 신청 상태를 변경하던중 에러발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+async function addClub(clubApplication){
+    try {
+        if(clubApplication.status === '거절됨'){
+            return;
+        }
+
+        const getApplicationQeury = `SELECT * FROM club_create_applications WHERE club_application_id = ?;`;
+        let applicationData = await executeQueryPromise(getApplicationQeury, [clubApplication.applicationId]);
+        applicationData = applicationData[0];
+
+        const availableCategory = await getLastCategory();
+        const addClubQuery = `INSERT INTO club (club_name, club_owner, create_day, member_count, category, affilition) VALUES (?, ?, ?, ?, ?, ?)`
+        await executeQueryPromise(addClubQuery, [applicationData.club_name, applicationData.user_id, applicationData.processed_date, applicationData.member_count, availableCategory, applicationData.affilition]);
+        
+        const addMemberDataQuery = `SELECT * FROM member WHERE user_id = ?`;
+        let memberData = await executeQueryPromise(addMemberDataQuery, [applicationData.user_id]);
+        memberData = memberData[0];
+
+        const addClubMemberQuery = `INSERT INTO club_member (category, user_id, member_name, member_student_id, member_department, member_ph_number, position, admin_ac) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+        await executeQueryPromise(addClubMemberQuery, [availableCategory, memberData.user_id, memberData.user_name, memberData.user_student_id, memberData.user_department, memberData.user_ph_number, '회장', '1']);
+        
+    } catch (error) {
+        console.error(`승인을 눌러 club, club_member 테이블에 값을 넣는중 오류 발생: ${error}`);
+    }
+}
+
+function findHighestCategory(categoryList) {
+    return categoryList.reduce((maxCategory, current) => Math.max(maxCategory, current.category), 0) + 1;
+}
+
+async function getLastCategory(){
+    try {
+        const query = `SELECT category FROM club;`;
+        result = await executeQueryPromise(query);
+        const availableCategory = findHighestCategory(result);
+        return availableCategory;
+    } catch (error) {
+        console.error(`club테이블의 마지막 category 값을 가져오는중에 오류 발생: ${error}`);
+    }
+}
+
+const saveEditApplication = async (req, res) => {
+    const resData = {};
+    try {
+        const editApplicationData = req.body;
+        const {club_name, member_count, affilition, user_ph_number, club_content, club_application_id} = editApplicationData.editApplicationData;
+
+        const query = `UPDATE club_create_applications SET club_name = ?, member_count = ?, affilition = ?, user_ph_number = ?, club_content = ? WHERE club_application_id = ?`;
+        await executeQueryPromise(query, [club_name, member_count, affilition, user_ph_number, club_content, club_application_id]);
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리 신청서를 수정하던중 에러발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
 module.exports = {
     setCreateClub,
     getCreateClubList,
+    deleteClubApplication,
+    getCreateClubApplicationListData,
+    getCreateClubApplicationData,
+    updateStatus,
+    saveEditApplication,
 }

--- a/app/src/controllers/tokenControllers/token.ctrl.js
+++ b/app/src/controllers/tokenControllers/token.ctrl.js
@@ -110,9 +110,34 @@ const isLogin = (req, res, next) => {
     }
 };
 
+//지금 로그인한 사용자가 환경변수로 지정한 admin계정인지 확인함.
+//동아리 등록신청한 페이지 (오로지 어드민으로 지정한 계정만 접근 가능.)
+const verifyTokenAdmin = (req, res, next) => {
+    // 클라이언트로부터 JWT를 받음
+    const token = req.cookies.accessToken;
+    // JWT가 없는 경우
+    if (!token) {
+        // return res.status(401).json({ message: '인증 토큰이 없습니다.' });
+        return res.redirect('/error-page');
+    }
+    try {
+        // JWT를 검증하여 페이로드(사용자 정보)를 추출
+        const decoded = jwt.verify(token, process.env.ACCESS_SECRET);
+        if(decoded.id !== process.env.ADMIN_ID){
+            return res.redirect('/error-page');
+        }
+        req.user = decoded; // 추출한 사용자 정보를 요청 객체에 저장
+        next(); // 다음 미들웨어로 이동
+    } catch (err) {
+        // return res.status(401).json({ message: '유효하지 않은 토큰입니다.' });
+        return res.redirect('/error-page');
+    }
+};
+
 module.exports = {
     refreshTokenMiddleware,
     getTokenDecode,
     verifyToken,
     isLogin,
+    verifyTokenAdmin,
 };

--- a/app/src/routes/pages-create-club.route.js
+++ b/app/src/routes/pages-create-club.route.js
@@ -1,16 +1,37 @@
 const express = require("express");
 const router = express.Router();
-const { verifyToken } = require('../controllers/tokenControllers/token.ctrl');
-const { setCreateClub, getCreateClubList } = require('../controllers/create-club.ctrl');
+const { verifyToken, verifyTokenAdmin } = require('../controllers/tokenControllers/token.ctrl');
+const { setCreateClub, 
+    getCreateClubList, 
+    deleteClubApplication, 
+    getCreateClubApplicationListData,
+    getCreateClubApplicationData,
+    updateStatus,
+    saveEditApplication,
+} 
+= require('../controllers/create-club.ctrl');
 
 router.get("/create-club", verifyToken, (req, res) => {
-    res.render("pages-create-club");
+    res.render("./createClubApplication/pages-create-club");
 });
 
 router.post("/api/create/club/post", setCreateClub);
 
 router.get("/api/create/club/list/get", getCreateClubList);
 
-router.delete("/api/create/club/delete");
+router.delete("/api/create/club/delete", deleteClubApplication);
+
+router.get("/create-club-admin-access", verifyTokenAdmin, (req, res) => {
+    res.render("./createClubApplication/createClubAdminAccess");
+});
+
+router.get("/api/create/club/list/admin/get", getCreateClubApplicationListData);
+
+//application_id에 해당하는 한개의 row 데이터만 가져옴.
+router.post("/api/create/club/application/data/get", getCreateClubApplicationData);
+
+router.put("/api/create/club/application/data/status/put", updateStatus);
+
+router.put("/api/create/club/application/data/edit/save", saveEditApplication);
 
 module.exports = router;

--- a/app/src/views/assets/js/createClub/createClub.js
+++ b/app/src/views/assets/js/createClub/createClub.js
@@ -24,7 +24,6 @@ async function createClub(createClubData) {
             throw new Error('네트워크 응답이 올바르지 않습니다.');
         }
         const data = await response.json();
-        console.log(data);
         if(!data.success){
             throw new Error('동아리(모임) 신청서를 제출하는데 실패 하였습니다.');
         }

--- a/app/src/views/assets/js/createClub/createClubAdminAccess.js
+++ b/app/src/views/assets/js/createClub/createClubAdminAccess.js
@@ -1,0 +1,289 @@
+function formatData(DBdate){
+    const date = new Date(DBdate);
+
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
+}
+
+function initializeDataTables() {
+    $('.table').DataTable({
+        language: {
+            url: "https://cdn.datatables.net/plug-ins/1.10.24/i18n/Korean.json"
+        },
+        pageLength: 5,
+        lengthMenu: [[5, 10, 15], [5, 10, 15]],
+        order: [[0, 'desc']]
+    });
+}
+
+async function getCreateClubApplicationListData(){
+    try {
+        const response = await fetch('/api/create/club/list/admin/get', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        if(!response.ok){
+            throw new Error(`네트워크 응답이 올바르지 않습니다.`);
+        }
+        const data = await response.json();
+
+        fillTableWithData(data.CreateClubList);
+        initializeDataTables();
+    } catch (error) {
+        alert(`동아리(모음) 신청서를 가져오던중 에러가 발생했습니다. ${error}`);
+        console.error(`에러가 발생했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+function fillTableWithData(data) {
+    // 상태별로 데이터 필터링
+    const pendingData = data.filter(item => item.application_status === '대기 중');
+    const approvedData = data.filter(item => item.application_status === '승인됨');
+    const rejectedData = data.filter(item => item.application_status === '거절됨');
+
+    // 각 탭에 데이터 채우기
+    fillTable('#pending tbody', pendingData);
+    fillTable('#approved tbody', approvedData);
+    fillTable('#rejected tbody', rejectedData);
+}
+
+function fillTable(selector, data) {
+    const tbody = document.querySelector(selector);
+    tbody.innerHTML = ''; // 기존 내용을 비웁니다.
+
+    data.forEach((item, index) => {
+        const badgeClass = getBadgeClass(item.application_status);
+        const processedDate = item.processed_date ? formatData(item.processed_date) : '-';
+        const row = `
+            <tr onclick=viewClubDetailModal(${item.club_application_id})>
+                <td>${index + 1}</td>
+                <td>${item.club_application_id}</td>
+                <td>${item.user_name}</td>
+                <td>${item.club_name}</td>
+                <td>${item.affilition}</td>
+                <td><span class="badge ${badgeClass}">${item.application_status}</span></td> <!-- 여기에 뱃지 적용 -->
+                <td>${formatData(item.application_date)}</td>
+                <td>${processedDate}</td>
+            </tr>
+        `;
+        tbody.innerHTML += row;
+    });
+}
+
+async function viewClubDetailModal(clubApplicationId){
+    const resData = await getCreateClubApplicationData(clubApplicationId)
+    let clubModal = new bootstrap.Modal(document.getElementById('clubModal'));
+
+    fillModalWithRowData(resData.CreateClubData);
+    clubModal.show();
+}
+
+function fillModalWithRowData(data) {
+    const badgeClass = getBadgeClass(data.application_status);
+    const statusElement = document.getElementById('modalApplicationStatus');
+    statusElement.className = '';
+    statusElement.classList.add('badge', badgeClass);
+    const processedDate = data.processed_date ? formatData(data.processed_date) : '-';
+    
+    setDisplayBtn(data);
+
+    document.getElementById('clubModalLabel').textContent = `신청서 고유 번호: ${data.club_application_id}`;
+    document.getElementById('modalClubName').textContent = `클럽 이름: ${data.club_name}`;
+    document.getElementById('modalAffiliation').textContent = `소속: ${data.affilition}`;
+    document.getElementById('modalApplicationDate').textContent = `신청 날짜: ${formatData(data.application_date)}`;
+    document.getElementById('modalApplicationProcessedDate').textContent = `처리 날짜: ${(processedDate)}`;
+    statusElement.textContent = `신청 상태: ${data.application_status}`;
+    document.getElementById('modalMemberCount').textContent = `회원 수: ${data.member_count}`;
+    const clubContentFromDB = data.club_content;
+    const clubContentHTML = clubContentFromDB.replace(/\n/g, '<br>');
+    document.getElementById('modalClubContent').innerHTML = clubContentHTML;
+}
+
+function setDisplayBtn(data){
+    const applicationStatus = data.application_status;
+    const approveBtn = document.getElementById('approveButton');
+    const rejectBtn = document.getElementById('rejectButton');
+    const editBtn = document.getElementById('editButton');
+
+    const clubApplicationId = data.club_application_id;
+    switch (applicationStatus) {
+        case '대기 중':
+            approveBtn.style.display = 'block';
+            rejectBtn.style.display = 'block';
+            approveBtn.setAttribute('data-application-id', clubApplicationId);
+            rejectBtn.setAttribute('data-application-id', clubApplicationId);
+            editBtn.setAttribute('data-application-id', clubApplicationId);
+            
+            return;
+        case '거절됨':
+        case '승인됨':
+            approveBtn.style.display = 'none';
+            rejectBtn.style.display = 'none';
+            editBtn.setAttribute('data-application-id', clubApplicationId);
+            break;
+        default:
+            break;
+    }
+}
+
+document.getElementById('approveButton').addEventListener('click', async () => {
+    const approveBtn = document.getElementById('approveButton');
+    const applicationId = approveBtn.dataset.applicationId;
+    await updateStatus(applicationId, "승인됨");
+})
+
+document.getElementById('rejectButton').addEventListener('click', async () => {
+    const rejectBtn = document.getElementById('rejectButton');
+    const applicationId = rejectBtn.dataset.applicationId;
+    await updateStatus(applicationId, "거절됨");
+})
+
+document.getElementById('editButton').addEventListener('click', async () => {
+    var editModal = new bootstrap.Modal(document.getElementById('editModal'), {});
+    editModal.show();
+
+    const editBtn = document.getElementById('editButton');
+    const applicationId = editBtn.dataset.applicationId;
+
+    const editSaveBtn = document.getElementById('editSaveBtn');
+    editSaveBtn.setAttribute('data-application-id', applicationId);
+
+    const resData = await getCreateClubApplicationData(applicationId)
+    fillEditModalWithRowData(resData.CreateClubData);
+})
+
+document.getElementById('editSaveBtn').addEventListener('click', async () => {
+    const editSaveBtn = document.getElementById('editSaveBtn');
+    const applicationId = editSaveBtn.dataset.applicationId;
+
+    const editApplicationData = getEditApplicationData();
+    editApplicationData.club_application_id = applicationId;
+    await saveEditApplication(editApplicationData);
+})
+
+function fillEditModalWithRowData(data) {
+    // 신청 상태에 따른 badgeClass 설정 및 텍스트 설정
+    const badgeClass = getBadgeClass(data.application_status);
+    const applicationStatusText = document.getElementById('applicationStatusText');
+    applicationStatusText.className = '';
+    applicationStatusText.classList.add('badge', badgeClass);
+    applicationStatusText.textContent = data.application_status || '-';
+    
+    // 신청 날짜 및 처리 날짜 텍스트 설정
+    document.getElementById('applicationDateText').textContent = data.application_date ? formatData(data.application_date) : '-';
+    document.getElementById('processedDateText').textContent = data.processed_date ? formatData(data.processed_date) : '-';
+
+    // 수정 가능한 입력 필드들에 데이터 할당
+    document.getElementById('clubNameInput').value = data.club_name || '';
+    document.getElementById('memberCountInput').value = data.member_count || '';
+    document.getElementById('affiliationInput').value = data.affilition || '';
+    document.getElementById('userPhoneInput').value = data.user_ph_number || '';
+    document.getElementById('clubContentInput').value = data.club_content || '';
+
+    document.getElementById('userIdText').textContent = data.user_id || '-';
+    document.getElementById('userNameText').textContent = data.user_name || '-';
+}
+
+async function updateStatus(applicationId, status){
+    try {
+        const response = await fetch('/api/create/club/application/data/status/put', {
+            method:'PUT',
+            body: JSON.stringify({applicationId, status}),
+            headers: {
+                'Content-Type':'application/json',
+            },
+        })
+        if(!response.ok){
+            throw new Error(`네트워크 응답이 올바르지 않습니다.`);
+        }
+        const data = await response.json();
+        if(!data.success){
+            throw new Error(`동아리 상태 처리에 실패하였습니다.`);
+        }
+        alert(`처리되었습니다.`);
+        window.location.reload();
+    } catch (error) {
+        alert(`동아리 신청서의 신청 상태를 변경하던중 에러가 발생했습니다. ${error}`);
+        console.error(`에러가 발생했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+async function saveEditApplication(editApplicationData){
+    try {
+        const response = await fetch('/api/create/club/application/data/edit/save', {
+            method:'PUT',
+            body: JSON.stringify({editApplicationData}),
+            headers: {
+                'Content-Type':'application/json',
+            },
+        });
+        if(!response.ok){
+            throw new Error(`네트워크 응답이 올바르지 않습니다.`);
+        }
+        const data = await response.json();
+        alert(`동아리 등록 신청서 수정후 저장이 처리되었습니다!`);
+        window.location.reload();
+    } catch (error) {
+        alert(`동아리 신청서를 수정하고 저장하는중에 에러가 발생했습니다. ${error}`);
+        console.error(`에러가 발생했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+function getEditApplicationData(){
+    const editInputApplicationData = {};
+
+    editInputApplicationData.club_name = document.getElementById('clubNameInput').value;
+    editInputApplicationData.member_count = document.getElementById('memberCountInput').value;
+    editInputApplicationData.affilition = document.getElementById('affiliationInput').value;
+    editInputApplicationData.user_ph_number = document.getElementById('userPhoneInput').value;
+    editInputApplicationData.club_content = document.getElementById('clubContentInput').value;
+
+    return editInputApplicationData;
+}
+
+//application_id에 해당하는 한개의 row를 가져옴.
+async function getCreateClubApplicationData(clubApplicationId){
+    try {
+        const response = await fetch('/api/create/club/application/data/get',{
+            method:'POST',
+            body: JSON.stringify({clubApplicationId}),
+            headers: {
+                'Content-Type':'application/json',
+            },
+        });
+        if(!response.ok){
+            throw new Error(`네트워크 응답이 올바르지 않습니다.`);
+        }
+        const data = await response.json();
+        return data;
+    } catch (error) {
+        alert(`동아리 신청서 세부데이터를 가져오던중 에러가 발생했습니다. ${error}`);
+        console.error(`에러가 발생했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+function getBadgeClass(status) {
+    switch (status) {
+        case '대기 중':
+            return 'bg-warning';
+        case '거절됨':
+            return 'bg-danger';
+        case '승인됨':
+            return 'bg-success';
+        default:
+            return 'bg-secondary';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    await getCreateClubApplicationListData();
+})

--- a/app/src/views/assets/js/createClub/modalCreateClubView.js
+++ b/app/src/views/assets/js/createClub/modalCreateClubView.js
@@ -24,7 +24,6 @@ async function getCreateClubList() {
             throw new Error(`네트워크 응답이 올바르지 않습니다.`);
         }
         const data = await response.json();
-        console.log(data);
 
         const listGroup = document.querySelector('#applicationListModal .list-group');
         listGroup.innerHTML = ''; 
@@ -54,23 +53,23 @@ async function getCreateClubList() {
 }
 
 function updateModalDetails(club) {
-    console.log(club);
     const modalTitle = document.querySelector('#applicationDetailsModalLabel');
     modalTitle.textContent = `#${club.club_application_id} ${club.club_name} 등록 신청 상세 정보`;
 
     const statusBadge = document.querySelector('#applicationDetailsModal .modal-body .badge');
-    statusBadge.className = 'badge'; // 기존 클래스 초기화
-    // getBadgeClass 함수를 사용하여 클래스 추가
+    statusBadge.className = 'badge';
     statusBadge.classList.add(getBadgeClass(club.application_status));
     statusBadge.textContent = club.application_status;
 
-    // 나머지 동아리 정보 업데이트
     document.querySelectorAll('#applicationDetailsModal .modal-body .row .col p')[0].textContent = `신청자: ${club.user_name}`;
     document.querySelectorAll('#applicationDetailsModal .modal-body .row .col p')[1].textContent = `연락처: ${club.user_ph_number}`;
     document.querySelectorAll('#applicationDetailsModal .modal-body .row .col p')[2].textContent = `동아리 이름: ${club.club_name}`;
     document.querySelectorAll('#applicationDetailsModal .modal-body .row .col p')[3].textContent = `동아리 소속: ${club.affilition}`;
     document.querySelector('#applicationDetailsModal .application-date').textContent = `신청 날짜: ${new Date(club.application_date).toLocaleDateString('ko-KR')}`;
-    document.querySelector('#applicationDetailsModal .application-purpose').textContent = `신청 목적: ${club.club_content}`;
+    const clubContentFromDB = club.club_content;
+    const clubContentHTML = clubContentFromDB.replace(/\n/g, '<br>');
+    document.querySelector('.application-purpose').innerHTML = clubContentHTML;
+
 
     // "신청 취소" 버튼의 표시 여부 결정
     const cancelButton = document.querySelector('#applicationDetailsModal .btn-danger');
@@ -82,20 +81,38 @@ function updateModalDetails(club) {
 
     // "신청 취소" 버튼에 클릭 이벤트 리스너 추가
     document.querySelector('#applicationDetailsModal .btn-danger').addEventListener('click', function() {
-        // "신청 취소 확인" 모달의 "신청 취소" 버튼에 data-application-id 속성 설정
         document.getElementById('deleteCreateClubBtn').setAttribute('data-application-id', club.club_application_id);
     });
 }
 
 document.getElementById('deleteCreateClubBtn').addEventListener('click', function() {
-    // "신청 취소" 버튼에서 data-application-id 속성을 통해 application_id 가져오기
-    const applicationId = this.getAttribute('data-application-id');
-    console.log('취소할 동아리의 application_id:', applicationId);
-
-    // 취소 로직을 여기에 구현...
+    const applicationId = this.getAttribute('data-application-id');    
+    deleteClubApplication(applicationId);
 });
 
+async function deleteClubApplication(applicationId){
+    try {
+        const response = await fetch('/api/create/club/delete', {
+            method:'DELETE',
+            body: JSON.stringify({applicationId}),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+        if(!response.ok){
+            throw new Error(`네트워크 응답이 올바르지 않습니다.`);
+        }
+        const data = await response.json();
+        if(!data.success){
+            throw new Error(`동아리 등록 신청을 취소하던중 에러가 발생했습니다.`);
+        }
+        alert(`${applicationId}번 신청에 대해서 취소하였습니다!`);
+    } catch (error) {
+        alert(`신청서를 취소하는중 오류가 발생했습니다. ${error}`);
+        console.error(`신청서를 취소하는중 오류가 발생했습니다. ${error}`);
+    }
+}
+
 document.getElementById('viewCreateClubList').addEventListener('click', async () => {
-    console.log('연결');
     await getCreateClubList();
 });

--- a/app/src/views/ejs-file/createClubApplication/createClubAdminAccess.ejs
+++ b/app/src/views/ejs-file/createClubApplication/createClubAdminAccess.ejs
@@ -1,0 +1,239 @@
+<!-- 헤더 include -->
+<%- include ('../partials/header.ejs') %>
+
+  <!-- ======= Sidebar ======= -->
+  <%- include ('../partials/sidebar.ejs') %>
+
+    <main id="main" class="main">
+      <div class="pagetitle">
+        <h1>어드민 관리 페이지</h1>
+        <nav>
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item active">동아리 등록/신청 승인</li>
+          </ol>
+        </nav>
+      </div><!-- End Page Title -->
+
+      <div class="container mt-5">
+        <!-- 탭 버튼들 -->
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a class="nav-link active" data-bs-toggle="tab" href="#pending">대기중</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" data-bs-toggle="tab" href="#approved">승인됨</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" data-bs-toggle="tab" href="#rejected">거절됨</a>
+          </li>
+        </ul>
+
+        <!-- 탭 내용 -->
+        <div class="tab-content">
+          <div id="pending" class="container tab-pane active"><br>
+            <!-- 대기중 테이블 -->
+            <table class="table table-hover">
+              <thead>
+                <tr>
+                  <th scope="col">#</th>
+                  <th scope="col">ID</th>
+                  <th scope="col">신청자</th>
+                  <th scope="col">동아리 이름</th>
+                  <th scope="col">동아리 소속</th>
+                  <th scope="col">신청 상태</th>
+                  <th scope="col">신청일</th>
+                  <th scope="col">처리일</th>
+                </tr>
+              </thead>
+              <tbody>
+                <!-- 서버에서 대기중인 신청 데이터 가져와서 표시 -->
+              </tbody>
+            </table>
+          </div>
+          <div id="approved" class="container tab-pane fade"><br>
+            <!-- 승인됨 테이블 -->
+            <table class="table">
+              <thead>
+                <tr>
+                  <th scope="col">#</th>
+                  <th scope="col">ID</th>
+                  <th scope="col">신청자</th>
+                  <th scope="col">동아리 이름</th>
+                  <th scope="col">동아리 소속</th>
+                  <th scope="col">신청 상태</th>
+                  <th scope="col">신청일</th>
+                  <th scope="col">처리일</th>
+                </tr>
+              </thead>
+              <tbody>
+                <!-- 서버에서 대기중인 신청 데이터 가져와서 표시 -->
+              </tbody>
+            </table>
+            <!-- 테이블 내용 동일하게 구성하여 서버에서 승인된 신청 데이터 가져와서 표시 -->
+          </div>
+          <div id="rejected" class="container tab-pane fade"><br>
+            <!-- 거절됨 테이블 -->
+            <table class="table">
+              <thead>
+                <tr>
+                  <th scope="col">#</th>
+                  <th scope="col">ID</th>
+                  <th scope="col">신청자</th>
+                  <th scope="col">동아리 이름</th>
+                  <th scope="col">동아리 소속</th>
+                  <th scope="col">신청 상태</th>
+                  <th scope="col">신청일</th>
+                  <th scope="col">처리일</th>
+                </tr>
+              </thead>
+              <tbody>
+                <!-- 서버에서 대기중인 신청 데이터 가져와서 표시 -->
+              </tbody>
+            </table>
+            <!-- 테이블 내용 동일하게 구성하여 서버에서 거절된 신청 데이터 가져와서 표시 -->
+          </div>
+        </div>
+      </div>
+
+      <!-- 동아리 등록 신청 디테일 모달 -->
+      <div class="modal fade" id="clubModal" tabindex="-1" aria-labelledby="clubModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="clubModalLabel">클럽 신청 정보</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <div class="card">
+                <div class="card-body">
+                  <h5 class="card-title" id="modalClubName">클럽 이름</h5>
+                  <h6 class="card-subtitle mb-2 text-muted" id="modalAffiliation">소속</h6>
+                  <p class="card-text">
+                    <span class="badge bg-primary" id="modalApplicationStatus">신청 상태</span>
+                  </p>
+                  <ul class="list-group list-group-flush">
+                    <li class="list-group-item" id="modalMemberCount">회원 수</li>
+                    <li class="list-group-item" id="modalApplicationDate">신청 날짜</li>
+                    <li class="list-group-item" id="modalApplicationProcessedDate">처리 날짜</li>
+                  </ul>
+                  <hr>
+                  <p class="card-text mt-3">클럽 내용:</p>
+                  <div class="card-text mt-3" id="modalClubContent">클럽 내용</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="modal-footer row">
+              <div class="col">
+                <button id="editButton" type="button" class="btn btn-primary" data-bs-dismiss="modal">수정</button>
+              </div>
+              <div class="col">
+                <button id="approveButton" type="button" class="btn btn-success" data-bs-dismiss="modal">승인</button>
+              </div>
+              <div class="col">
+                <button id="rejectButton" type="button" class="btn btn-danger" data-bs-dismiss="modal">거절</button>
+              </div>
+              <div class="col">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 편집 모달 -->
+      <div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="editModalLabel">클럽 정보 편집</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <div class="card">
+                <div class="card-body">
+                  <form id="editForm">
+                    <!-- 텍스트로 표시할 필드들 -->
+                    <div class="mb-3">
+                      <h6 class="card-subtitle mt-3 mb-2 text-muted">사용자 ID</h6>
+                      <p class="card-text" id="userIdText">-</p>
+                    </div>
+                    <div class="mb-3">
+                      <h6 class="card-subtitle mb-2 text-muted">사용자 이름</h6>
+                      <p class="card-text" id="userNameText">-</p>
+                    </div>
+                    <div class="mb-3">
+                      <h6 class="card-subtitle mb-2 text-muted">신청 상태</h6>
+                      <p class="card-text" id="applicationStatusText">-</p>
+                    </div>
+                    <div class="mb-3">
+                      <h6 class="card-subtitle mb-2 text-muted">신청 날짜</h6>
+                      <p class="card-text" id="applicationDateText">-</p>
+                    </div>
+                    <div class="mb-3">
+                      <h6 class="card-subtitle mb-2 text-muted">처리 날짜</h6>
+                      <p class="card-text" id="processedDateText">-</p>
+                    </div>
+                    <!-- 수정 가능한 input 필드들 -->
+                    <div class="mb-3">
+                      <label for="clubNameInput" class="form-label">클럽 이름</label>
+                      <input type="text" class="form-control" id="clubNameInput">
+                    </div>
+                    <div class="mb-3">
+                      <label for="memberCountInput" class="form-label">멤버 수</label>
+                      <input type="number" class="form-control" id="memberCountInput">
+                    </div>
+                    <div class="mb-3">
+                      <label for="affiliationInput" class="form-label">소속</label>
+                      <input type="text" class="form-control" id="affiliationInput">
+                    </div>
+                    <div class="mb-3">
+                      <label for="userPhoneInput" class="form-label">연락처</label>
+                      <input type="tel" class="form-control" id="userPhoneInput">
+                    </div>
+                    <div class="mb-3">
+                      <label for="clubContentInput" class="form-label">클럽 내용</label>
+                      <textarea class="form-control" id="clubContentInput" rows="3"></textarea>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+              <button id="editSaveBtn" type="button" class="btn btn-primary">저장</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main><!-- End #main -->
+
+    <!-- ======= Footer ======= -->
+    <%- include ('../partials/footer.ejs') %>
+      <!-- End Footer -->
+
+      <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i
+          class="bi bi-arrow-up-short"></i></a>
+
+      <!-- Vendor JS Files -->
+      <script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+      <script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js"></script>
+      <script src="assets/vendor/apexcharts/apexcharts.min.js"></script>
+      <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+      <script src="assets/vendor/chart.js/chart.umd.js"></script>
+      <script src="assets/vendor/echarts/echarts.min.js"></script>
+      <script src="assets/vendor/quill/quill.min.js"></script>
+      <script src="assets/vendor/simple-datatables/simple-datatables.js"></script>
+      <script src="assets/vendor/tinymce/tinymce.min.js"></script>
+      <script src="assets/vendor/php-email-form/validate.js"></script>
+
+      <!-- Template Main JS File -->
+      <script src="assets/js/main.js"></script>
+
+      <!--Client JS File-->
+      <script defer src="../../assets/js/createClub/createClubAdminAccess.js"></script>
+
+      </body>
+
+      </html>

--- a/app/src/views/ejs-file/createClubApplication/pages-create-club.ejs
+++ b/app/src/views/ejs-file/createClubApplication/pages-create-club.ejs
@@ -1,8 +1,8 @@
 <!-- 헤더 include -->
-<%- include ('partials/header.ejs') %>
+<%- include ('../partials/header.ejs') %>
 
   <!-- ======= Sidebar ======= -->
-  <%- include ('partials/sidebar.ejs') %>
+  <%- include ('../partials/sidebar.ejs') %>
 
     <main id="main" class="main">
 
@@ -232,7 +232,9 @@
                 </div>
               </div>
                 <p class="application-date"></p>
-                <p class="application-purpose"></p>
+                <hr>
+                <p>신청 목적:</p>
+                <div class="application-purpose"></div>
             </div>
             <div class="modal-footer">
               <!-- 신청 취소 버튼 추가 -->
@@ -267,7 +269,7 @@
     </main><!-- End #main -->
 
     <!-- ======= Footer ======= -->
-    <%- include ('partials/footer.ejs') %>
+    <%- include ('../partials/footer.ejs') %>
       <!-- End Footer -->
 
       <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i
@@ -287,8 +289,8 @@
       <script src="assets/js/main.js"></script>
 
       <!--Client JS File-->
-      <script defer src="../assets/js/createClub/createClub.js"></script>
-      <script defer src="../assets/js/createClub/modalCreateClubView.js"></script>
+      <script defer src="../../assets/js/createClub/createClub.js"></script>
+      <script defer src="../../assets/js/createClub/modalCreateClubView.js"></script>
 
       </body>
 

--- a/app/src/views/ejs-file/partials/header.ejs
+++ b/app/src/views/ejs-file/partials/header.ejs
@@ -36,7 +36,7 @@
   <!--Quill Editer-->
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" />
   <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
-  
+
   <!-- =======================================================
   * Template Name: NiceAdmin
   * Updated: Mar 12 2024 with Bootstrap v5.3.3
@@ -295,15 +295,29 @@
                   <span>마이페이지</span>
                 </a>
               </li>
-                  <li>
-                    <hr class="dropdown-divider">
-                  </li>
-                  <li>
-                    <a class="dropdown-item d-flex align-items-center" href="/api/users/logout">
-                      <i class="bi bi-pencil-square"></i>
-                      <span>로그아웃</span>
-                    </a>
-                  </li>
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li>
+                <a class="dropdown-item d-flex align-items-center" href="/api/users/logout">
+                  <i class="bi bi-pencil-square"></i>
+                  <span>로그아웃</span>
+                </a>
+              </li>
+              <% if (userData.user_id==='kimboseok@naver.com' ) { %>
+
+                <li>
+                  <hr class="dropdown-divider">
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" href="/create-club-admin-access">
+                    <i class="bi bi-shield-lock"></i>
+                    <span>동아리 등록 신청 처리</span>
+                  </a>
+                </li>
+                <% } else { %>
+                  <% } %>
+
             </ul>
           </li>
           <% } else { %>


### PR DESCRIPTION
<동아리 등록 신청 승인 페이지 - 특정 계정만 접근 가능>
1. http://127.0.0.1:3000/create-club-admin-access 가 해당 페이지입니다.

2. 해당 페이지는 kimboseok@naver.com 계정만 접근이 가능합니다. 다른 계정은 모두 접속시 Error 페이지를 띄움.

3. kimboseok@naver.com 계정으로 접속하면 헤더에 드롭 메뉴에서 바로 접속이 가능합니다.

4. 테이블에서 확인하고 싶은 row을 클릭하면 해당 정보를 보여주는 모달이 띄워지고 거기서 모든 편집, 승인, 거절 처리가 가능합니다.

5. 접속시 대기중, 승인됨, 거절됨 테이블이 나오고 모든 동아리 신청 현황을 보고 승인, 거절, 편집이 가능합니다.

6. 승인시 해당 동아리 정보로 동아리가 생성되고 바로 DB에도 모두 반영되고 모든 동아리 활동 시작 가능합니다.

7. 구현된 기능은 직접 한번씩 눌러서 보는게 가장 이해하기 쉽습니다.

8. .env 파일에서 어드민 계정 변수를 추가해야 정상적으로 접근 가능합니다.