### PR TITLE
동아리 가입 신청에 대한 club 페이지에서 가입 신청 현황에서 핸들링이 가능합니다

### DIFF
--- a/app/src/config/database.js
+++ b/app/src/config/database.js
@@ -3,7 +3,7 @@ const dotenv = require("dotenv");
 dotenv.config();
 
 const pool = mysql.createPool({
-  connectionLimit: 50,
+  connectionLimit: 100,
   host: process.env.DB_HOST,
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,

--- a/app/src/controllers/clubAdminControllers/clubAdminApplication.ctrl.js
+++ b/app/src/controllers/clubAdminControllers/clubAdminApplication.ctrl.js
@@ -1,0 +1,91 @@
+const { executeQueryPromise } = require("../../config/database.func");
+const { getTokenDecode } = require("../../controllers/tokenControllers/token.ctrl");
+const { formatDate } = require("../create-club.ctrl");
+
+async function getMemberData(userId){
+    try {
+        const userDataQuery = `SELECT user_id, user_name, user_student_id, user_department, user_ph_number FROM member WHERE user_id = ?`;
+        let memberData = await executeQueryPromise(userDataQuery, [userId]);
+        memberData = memberData[0];
+        return memberData;
+    } catch (error) {
+        console.error(`member 테이블의 회원정보 조회중 에러발생: ${error}`);
+    }
+}
+
+const clubApplication = async (req, res) => {
+    const resData = {};
+    try {
+        const category = req.query.query;
+        const query = `SELECT * FROM club_applications WHERE category = ?;`;
+        const applications = await executeQueryPromise(query, [category]);
+
+        const applicationsWithUserData = await Promise.all(applications.map(async (application) => {
+            const userData = await getMemberData(application.user_id);
+            return { ...application, ...userData };
+        }));
+
+        resData.success = true;
+        resData.clubApplicationList = applicationsWithUserData;
+
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리 신청 정보 조회중 에러발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const clubApplicationStatusUpdate = async (req, res) => {
+    const resData = {};
+    try {
+        const date = formatDate();
+        const updateData = req.body;
+        const {
+            application_id,
+            user_id,
+            category,
+            user_name,
+            user_student_id,
+            user_department,
+            user_ph_number
+        } = updateData.applicationDetail;
+
+        if(await isUserRegistered(user_student_id, category)){
+            updateData.status = '거절됨';
+            resData.isUserMember = true;
+        }
+
+        const statusQuery = `UPDATE club_applications SET application_status = ?, processed_date = ? WHERE application_id = ?`;
+        
+        await executeQueryPromise(statusQuery, [updateData.status, date, application_id]);
+        
+        if(updateData.status === '승인됨'){
+            const addClubMemberQuery = `INSERT INTO club_member (category, user_id, member_name, member_student_id, member_department, member_ph_number, position, admin_ac) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+            await executeQueryPromise(addClubMemberQuery, [category, user_id, user_name, user_student_id, user_department, user_ph_number, '부원', '0']);
+        }
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리 가입 신청서 처리중에 에러 발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+async function isUserRegistered(studentId, category){
+    try {
+        const checkQuery = `SELECT * FROM club_member WHERE member_student_id = ? AND category = ?;`;
+        const result = await executeQueryPromise(checkQuery, [studentId, category]);
+
+        if(result.length === 0) return false;
+        return true;
+    } catch (error) {
+        console.error(`이미 가입된 유저인지 체크하는중에 에러발생: ${error}`);
+    }
+}
+
+module.exports = {
+    clubApplication,
+    clubApplicationStatusUpdate,
+}

--- a/app/src/controllers/create-club.ctrl.js
+++ b/app/src/controllers/create-club.ctrl.js
@@ -212,4 +212,5 @@ module.exports = {
     getCreateClubApplicationData,
     updateStatus,
     saveEditApplication,
+    formatDate,
 }

--- a/app/src/routes/pages-clubAdmin.route.js
+++ b/app/src/routes/pages-clubAdmin.route.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const clubAdminController = require("./../controllers/clubAdmin.ctrl");
 const {verifyToken} = require("../controllers/tokenControllers/token.ctrl");
+const { clubApplication, clubApplicationStatusUpdate } = require("../controllers/clubAdminControllers/clubAdminApplication.ctrl");
 
 // 회원 목록을 가져오는 라우터
 router.get("/Page-clubAdmin", verifyToken, clubAdminController.isClubMember, clubAdminController.getClubMember);
@@ -13,5 +14,10 @@ router.post("/new-member", clubAdminController.newMember);
 router.post("/delete-member", clubAdminController.deleteMember);
 
 router.post("/update-member", clubAdminController.updateMember);
+
+//가입 신청 현황 라우터
+router.get("/api/club/application/list/get", clubApplication);
+
+router.put("/api/club/application/update/status", clubApplicationStatusUpdate);
 
 module.exports = router;

--- a/app/src/views/assets/js/pagesAdmin/admin_club_applications.js
+++ b/app/src/views/assets/js/pagesAdmin/admin_club_applications.js
@@ -1,0 +1,215 @@
+function formatData(DBdate){
+    const date = new Date(DBdate);
+
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
+}
+
+function initializeDataTables() {
+    $('.club-application-table').DataTable({
+        language: {
+            url: "https://cdn.datatables.net/plug-ins/1.10.24/i18n/Korean.json"
+        },
+        pageLength: 5,
+        lengthMenu: [[5, 10, 15], [5, 10, 15]],
+        order: [[0, 'desc']]
+    });
+}
+
+function fillTableWithData(data) {
+    // 상태별로 데이터 필터링
+    const pendingData = data.filter(item => item.application_status === '대기 중');
+    const approvedData = data.filter(item => item.application_status === '승인됨');
+    const rejectedData = data.filter(item => item.application_status === '거절됨');
+
+    // 각 탭에 데이터 채우기
+    fillTable('#pending tbody', pendingData);
+    fillTable('#approved tbody', approvedData);
+    fillTable('#rejected tbody', rejectedData);
+}
+
+function getBadgeClass(status) {
+    switch (status) {
+        case '대기 중':
+            return 'bg-warning';
+        case '거절됨':
+            return 'bg-danger';
+        case '승인됨':
+            return 'bg-success';
+        default:
+            return 'bg-secondary';
+    }
+}
+
+function fillTable(selector, data) {
+    const tbody = document.querySelector(selector);
+    tbody.innerHTML = ''; // 기존 내용을 비웁니다.
+
+    data.forEach((item, index) => {
+        const badgeClass = getBadgeClass(item.application_status);
+        const processedDate = item.processed_date ? formatData(item.processed_date) : '-';
+        const row = `
+            <tr onclick=viewApplicationDetailModal(${item.application_id})>
+                <td>${item.application_id}</td>
+                <td>${item.user_name}</td>
+                <td>${item.gender}</td>
+                <td><span class="badge ${badgeClass}">${item.application_status}</span></td>
+                <td>${formatData(item.application_date)}</td>
+                <td>${processedDate}</td>
+            </tr>
+        `;
+        tbody.innerHTML += row;
+    });
+}
+
+function getCategory() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const category = urlParams.get('query');
+
+    return category;
+}
+
+async function getClubApplicationList(isGetData){
+    try {
+        const category = getCategory();
+        const response = await fetch(`/api/club/application/list/get?query=${category}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        if(!response.ok){
+            throw new Error(`네트워크 응답이 올바르지 않습니다.`);
+        }
+        const data = await response.json();
+
+        if(isGetData){
+            return data.clubApplicationList;
+        }
+
+        fillTableWithData(data.clubApplicationList);
+        initializeDataTables();
+    } catch (error) {
+        alert(`가입 신청 현황을 가져오던중 에러가 발생했습니다. ${error}`);
+        console.error(`에러가 발생했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+async function viewApplicationDetailModal(applicationId){
+    try {
+        const resData = await getClubApplicationList(true);
+        const applicationDetail = resData.find(app => app.application_id === applicationId);
+
+        let clubModal = new bootstrap.Modal(document.getElementById('clubModal'));
+        clubModal.show();
+        fillModalWithRowData(applicationDetail);
+    } catch (error) {
+        alert(`해당 신청서의 세부 정보를 가져오던중 에러가 발생했습니다. ${error}`);
+        console.error("해당하는 신청서 정보를 찾을 수 없습니다.");
+    }
+}
+
+function setDisplayBtn(data){
+    const applicationStatus = data.application_status;
+    const approveBtn = document.getElementById('approveButton');
+    const rejectBtn = document.getElementById('rejectButton');
+
+    const clubApplicationId = data.application_id;
+    switch (applicationStatus) {
+        case '대기 중':
+            approveBtn.style.display = 'block';
+            rejectBtn.style.display = 'block';
+            approveBtn.setAttribute('data-application-id', clubApplicationId);
+            rejectBtn.setAttribute('data-application-id', clubApplicationId);
+            break;
+        case '거절됨':
+        case '승인됨':
+            approveBtn.style.display = 'none';
+            rejectBtn.style.display = 'none';
+            break;
+        default:
+            break;
+    }
+}
+
+function fillModalWithRowData(data) {
+    const badgeClass = getBadgeClass(data.application_status);
+    const statusElement = document.getElementById('modalApplicationStatus');
+    statusElement.className = '';
+    statusElement.classList.add('badge', badgeClass);
+    const processedDate = data.processed_date ? formatData(data.processed_date) : '-';
+    
+    setDisplayBtn(data);
+
+    document.getElementById('modalApplicationID').textContent = data.application_id;
+    statusElement.textContent = data.application_status;
+
+    document.getElementById('modalUserID').textContent = data.user_id;
+    document.getElementById('modalUserName').textContent = data.user_name;
+    document.getElementById('modalStudentID').textContent = data.user_student_id;
+    document.getElementById('modalDepartment').textContent = data.user_department;
+    document.getElementById('modalPhone').textContent = data.user_ph_number;
+    
+    document.getElementById('modalGender').textContent = data.gender;
+    document.getElementById('modalRegion').textContent = data.residence;
+    document.getElementById('modalApplicationDate').textContent = formatData(data.application_date);
+    document.getElementById('modalApplicationProcessedDate').textContent = processedDate;
+    
+    const introductionFromDB = data.introduction;
+    const introductionHTML = introductionFromDB.replace(/\n/g, '<br>');
+    document.getElementById('modalSelfIntroduction').innerHTML = introductionHTML;
+}
+
+document.getElementById('approveButton').addEventListener('click', async () => {
+    const approveBtn = document.getElementById('approveButton');
+    const applicationId = parseInt(approveBtn.dataset.applicationId, 10);
+
+    const resData = await getClubApplicationList(true);
+    const applicationDetail = resData.find(app => app.application_id === applicationId);
+
+    await updateStatusDB(applicationDetail, '승인됨');
+})
+
+document.getElementById('rejectButton').addEventListener('click', async () => {
+    const rejectBtn = document.getElementById('rejectButton');
+    const applicationId = parseInt(rejectBtn.dataset.applicationId, 10);
+
+    const resData = await getClubApplicationList(true);
+    const applicationDetail = resData.find(app => app.application_id === applicationId);
+
+    await updateStatusDB(applicationDetail, '거절됨');
+})
+
+async function updateStatusDB(applicationDetail, status){
+    try {
+        const response = await fetch('/api/club/application/update/status', {
+            method: 'PUT',
+            body: JSON.stringify({applicationDetail, status}),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        if(!response.ok){
+            throw new Error(`네트워크 응답이 올바르지 않습니다.`);
+        }
+        const data = await response.json();
+        if(data.isUserMember !== undefined && data.isUserMember){
+            alert(`해당 유저는 이미 가입이 된 유저입니다. 거절 처리 되었습니다. (학번이 동일한 유저가 있습니다.)`);
+        }
+        if(data.success){
+            window.location.reload();
+        }
+    } catch (error) {
+        alert(`해당 신청서를 처리하는데 에러가 발생했습니다. ${error}`);
+        console.error("해당 신청서를 처리하는데 에러가 발생했습니다.");
+        window.location.reload();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    await getClubApplicationList();
+})

--- a/app/src/views/ejs-file/pages-clubAdmin.ejs
+++ b/app/src/views/ejs-file/pages-clubAdmin.ejs
@@ -122,59 +122,78 @@
                             </div>
 
                             <div class="tab-pane fade pt-3" id="profile-settings">
+                                <div class="container">
+                                    <!-- 탭 버튼들 -->
+                                    <ul class="nav nav-tabs">
+                                        <li class="nav-item">
+                                            <a class="nav-link active" data-bs-toggle="tab"
+                                                href="#pending">대기중</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link" data-bs-toggle="tab" href="#approved">승인됨</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link" data-bs-toggle="tab" href="#rejected">거절됨</a>
+                                        </li>
+                                    </ul>
 
-                                <div class="card mb-3" >
-                                    <div class="row g-0">
-                                        <div class="col-md-3">
-                                            <img src="assets/img/card.jpg" class="img-fluid rounded-start" alt="...">
+                                    <!-- 탭 내용 -->
+                                    <div class="tab-content">
+                                        <div id="pending" class="container tab-pane active"><br>
+                                            <!-- 대기중 테이블 -->
+                                            <table class="table table-hover club-application-table">
+                                                <thead>
+                                                    <tr>
+                                                        <th scope="col">#</th>
+                                                        <th scope="col">신청자</th>
+                                                        <th scope="col">성별</th>
+                                                        <th scope="col">신청 상태</th>
+                                                        <th scope="col">신청일</th>
+                                                        <th scope="col">처리일</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <!-- 서버에서 대기중인 신청 데이터 가져와서 표시 -->
+                                                </tbody>
+                                            </table>
                                         </div>
-                                        <div class="col-md-9">
-                                            <div class="card-body">
-                                                <h5 class="card-title">게시글 제목</h5>
-                                                <p class="card-text">동아리 설명</p>
-                                            </div>
+                                        <div id="approved" class="container tab-pane fade"><br>
+                                            <!-- 승인됨 테이블 -->
+                                            <table class="table table-hover club-application-table">
+                                                <thead>
+                                                    <tr>
+                                                        <th scope="col">#</th>
+                                                        <th scope="col">신청자</th>
+                                                        <th scope="col">성별</th>
+                                                        <th scope="col">신청 상태</th>
+                                                        <th scope="col">신청일</th>
+                                                        <th scope="col">처리일</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <!-- 서버에서 대기중인 신청 데이터 가져와서 표시 -->
+                                                </tbody>
+                                            </table>
+                                            <!-- 테이블 내용 동일하게 구성하여 서버에서 승인된 신청 데이터 가져와서 표시 -->
                                         </div>
-                                    </div>
-                                </div>
-
-                                <div class="card mb-3" >
-                                    <div class="row g-0">
-                                        <div class="col-md-3">
-                                            <img src="assets/img/card.jpg" class="img-fluid rounded-start" alt="...">
-                                        </div>
-                                        <div class="col-md-9">
-                                            <div class="card-body">
-                                                <h5 class="card-title">게시글 제목</h5>
-                                                <p class="card-text">동아리 설명</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="card mb-3" >
-                                    <div class="row g-0">
-                                        <div class="col-md-3">
-                                            <img src="assets/img/card.jpg" class="img-fluid rounded-start" alt="...">
-                                        </div>
-                                        <div class="col-md-9">
-                                            <div class="card-body">
-                                                <h5 class="card-title">게시글 제목</h5>
-                                                <p class="card-text">동아리 설명</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="card mb-3" >
-                                    <div class="row g-0">
-                                        <div class="col-md-3">
-                                            <img src="assets/img/card.jpg" class="img-fluid rounded-start" alt="...">
-                                        </div>
-                                        <div class="col-md-9">
-                                            <div class="card-body">
-                                                <h5 class="card-title">게시글 제목</h5>
-                                                <p class="card-text">동아리 설명</p>
-                                            </div>
+                                        <div id="rejected" class="container tab-pane fade"><br>
+                                            <!-- 거절됨 테이블 -->
+                                            <table class="table table-hover club-application-table">
+                                                <thead>
+                                                    <tr>
+                                                        <th scope="col">#</th>
+                                                        <th scope="col">신청자</th>
+                                                        <th scope="col">성별</th>
+                                                        <th scope="col">신청 상태</th>
+                                                        <th scope="col">신청일</th>
+                                                        <th scope="col">처리일</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <!-- 서버에서 대기중인 신청 데이터 가져와서 표시 -->
+                                                </tbody>
+                                            </table>
+                                            <!-- 테이블 내용 동일하게 구성하여 서버에서 거절된 신청 데이터 가져와서 표시 -->
                                         </div>
                                     </div>
                                 </div>
@@ -246,6 +265,52 @@
 
     </section>
 
+    <!-- 동아리 가입 신청 디테일 모달 -->
+    <div class="modal fade" id="clubModal" tabindex="-1" aria-labelledby="clubModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="clubModalLabel">동아리 가입 신청 정보</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row mb-3">
+                        <div class="col-md-6 mb-2">
+                            <strong>신청 고유 번호:</strong> <span id="modalApplicationID">-</span>
+                        </div>
+                        <div class="col-md-6 mb-2">
+                            <strong>신청 상태:</strong> <span id="modalApplicationStatus" class="badge bg-primary">-</span>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="mb-2"><strong>유저 ID:</strong> <span id="modalUserID">-</span></div>
+                            <div class="mb-2"><strong>이름:</strong> <span id="modalUserName">-</span></div>
+                            <div class="mb-2"><strong>학번:</strong> <span id="modalStudentID">-</span></div>
+                            <div class="mb-2"><strong>학과:</strong> <span id="modalDepartment">-</span></div>
+                            <div class="mb-2"><strong>핸드폰번호:</strong> <span id="modalPhone">-</span></div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="mb-2"><strong>성별:</strong> <span id="modalGender">-</span></div>
+                            <div class="mb-2"><strong>지역:</strong> <span id="modalRegion">-</span></div>
+                            <div class="mb-2"><strong>신청일:</strong> <span id="modalApplicationDate">-</span></div>
+                            <div class="mb-2"><strong>처리일:</strong> <span id="modalApplicationProcessedDate">-</span></div>
+                        </div>
+                    </div>
+                    <hr>
+                    <div>
+                        <strong>자기소개:</strong>
+                        <div class="card-text mt-3" id="modalSelfIntroduction">-</div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button id="approveButton" type="button" class="btn btn-success" data-bs-dismiss="modal">승인</button>
+                    <button id="rejectButton" type="button" class="btn btn-danger" data-bs-dismiss="modal">거절</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </main><!-- End #main -->
 
 <!-- ======= Footer ======= -->
@@ -255,6 +320,8 @@
 <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
 
 <!-- Vendor JS Files -->
+<script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+<script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js"></script>
 <script src="assets/vendor/apexcharts/apexcharts.min.js"></script>
 <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 <script src="assets/vendor/chart.js/chart.umd.js"></script>
@@ -273,7 +340,9 @@
     });
 </script>
 
+<!--Client JS File-->
 <script defer src="../assets/js/pagesAdmin/admin_edit.js"></script>
+<script defer src="../assets/js/pagesAdmin/admin_club_applications.js"></script>
 
 </body>
 


### PR DESCRIPTION
<동아리 가입 처리에 대한 로직 구현 스팩>
1. 가입 신청은 이전에 구현된것 처럼 홍보 게시글에서 본문하단에 "신청하기 버튼"을 통해 신청을 합니다.

2. club 페이지에서 동아리 관리 권한(admin_ac)가 있는 유저가 "가입 신청 현황" 탭을 들어가면 "대기중", "승인됨", "거절됨" 탭으로 구성된 테이블을 볼수 있습니다.

3. 해당 테이블의 row를 클릭하면 신청에 대한 디테일한 정보를 모달로 띄워줍니다.

4. 디테일 모달을 띄웠을때 하단에 "승인", "거절", "닫기" 버튼이 있습니다. 그중 "승인", "거절"은 "대기 중" 인 상태의 신청에만 보입니다.
=> "승인됨" 또는 "거절됨" 으로 넘어간 신청서의 디테일 모달은 "닫기" 버튼만 있습니다.

5. 만약 이미 가입되어있는 유저의 신청서를 "승인" 버튼을 누르면 alert으로 해당 유저는 이미 가입된 유저라고 핸들링을 해줍니다.
