### PR TITLE
메인 대시보드 동아리 홍보 게시글 전체, 모집중, 마감됨 탭으로 구분

### DIFF
--- a/app/src/views/ejs-file/index.ejs
+++ b/app/src/views/ejs-file/index.ejs
@@ -34,10 +34,49 @@
                   </button>
                 </a>
               </div>
-              <div id="card-container" class="row row-cols-1 row-cols-md-3 g-4">
+
+              <!-- 탭 버튼 -->
+              <ul class="nav nav-tabs" id="myTab" role="tablist">
+                <li class="nav-item" role="presentation">
+                  <button class="nav-link active" id="all-tab" data-bs-toggle="tab" data-bs-target="#all" type="button"
+                    role="tab" aria-controls="all" aria-selected="true">전체</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <button class="nav-link" id="recruiting-tab" data-bs-toggle="tab" data-bs-target="#recruiting"
+                    type="button" role="tab" aria-controls="recruiting" aria-selected="false">모집중</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <button class="nav-link" id="closed-tab" data-bs-toggle="tab" data-bs-target="#closed" type="button"
+                    role="tab" aria-controls="closed" aria-selected="false">마감됨</button>
+                </li>
+              </ul>
+
+              <!-- 탭 컨텐츠 -->
+              <div class="tab-content" id="myTabContent">
+                <div class="tab-pane fade show active" id="all" role="tabpanel" aria-labelledby="all-tab">
+                  <div id="cards-container" class="row">
+                    <div id="card-container" class="row row-cols-1 row-cols-md-3 g-4"></div>
+                  </div>
+                </div>
+
+                <div class="tab-pane fade" id="recruiting" role="tabpanel" aria-labelledby="recruiting-tab">
+                  <div id="cards-container-recruiting" class="row">
+                    <div id="card-container-recruiting" class="row row-cols-1 row-cols-md-3 g-4"></div>
+                  </div>
+                </div>
+                <div class="tab-pane fade" id="closed" role="tabpanel" aria-labelledby="closed-tab">
+                  <div id="cards-container-closed" class="row">
+                    <div id="card-container-closed" class="row row-cols-1 row-cols-md-3 g-4"></div>
+                  </div>
+                </div>
               </div>
+              <nav aria-label="Page navigation">
+                <ul id="pagination" class="pagination">
+                </ul>
+              </nav>
             </div>
           </div>
+        </div>
         </div>
       </section>
 


### PR DESCRIPTION
기존:
메인 대시보드에 보여지는 게시글이 기존에는 최신순으로 정렬되었습니다.

변경후:
1. 게시글 상단에 "전체", "모집중", "마감됨" 탭을 만들어서 각자의 탭에 올바른 게시글이 들어가도록 설정 하였습니다.
 
2. 각자의 탭에 대해서 게시글이 9개가 넘어가면 다음 페이지를 보여줄수 있도록 페이지 네이션 기능을 추가하였습니다.

#기존 코드를 많이 안고치고 하려고 했어서 조금 비효율적인 코드가 된것 같아서 아쉽네요...