### PR TITLE
회원 탈퇴 로직 구현 완료

### DIFF
--- a/app/src/controllers/profileCtrollers/profileDeleteAccount.ctrl.js
+++ b/app/src/controllers/profileCtrollers/profileDeleteAccount.ctrl.js
@@ -1,0 +1,102 @@
+const { executeQueryPromise } = require("../../config/database.func");
+const { getTokenDecode } = require("../tokenControllers/token.ctrl");
+const { getUser } = require("../login.ctrl");
+const { isClubOwner } = require("../index.ctrl");
+const bcrypt = require("bcrypt");
+
+const checkPw = async (req, res) => {
+    const resData = {};
+    try {
+        const { pw } = req.body;
+        const accessTokenDecoded = await getTokenDecode(req, res);
+
+        const userDataMember = await getUser(accessTokenDecoded.id);
+        if (userDataMember.length === 0) {
+            resData.success = false;
+            resData.msg = '사용자를 찾을 수 없습니다.';
+            res.status(200).json(resData);
+            return;
+        }
+
+        const isMatch = await bcrypt.compare(pw, userDataMember.user_pw);
+
+        if (!isMatch) {
+            resData.success = false;
+            resData.msg = '비밀번호를 다시 확인해주세요.';
+            res.status(200).json(resData);
+            return;
+        }
+
+        const { isOwner } = await isClubOwner(accessTokenDecoded.id);
+        if(isOwner){
+            resData.success = false;
+            resData.msg = '동아리 회장(대표)는 권한을 위임해야만 탈퇴가 가능합니다.';
+            res.status(200).json(resData);
+            return;
+        }
+
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        resData.success = false;
+        resData.msg = '비밀번호 확인중 에러가 발생했습니다.';
+        console.error('비밀번호 확인중 에러가 발생했습니다.', error);
+        res.status(500).json(resData);
+    }
+}
+
+const deleteAccount = async (req, res) => {
+    const resData = {};
+    try {
+        const { pw } = req.body;
+        const accessTokenDecoded = await getTokenDecode(req, res);
+
+        const userDataMember = await getUser(accessTokenDecoded.id);
+        if (userDataMember.length === 0) {
+            resData.success = false;
+            resData.msg = '사용자를 찾을 수 없습니다.';
+            res.status(200).json(resData);
+            return;
+        }
+
+        const isMatch = await bcrypt.compare(pw, userDataMember.user_pw);
+
+        if (!isMatch) {
+            resData.success = false;
+            resData.msg = '비밀번호를 다시 확인해주세요.';
+            res.status(200).json(resData);
+            return;
+        }
+        await executeQueryPromise('START TRANSACTION');
+
+        const queryClubMember = `DELETE FROM club_member WHERE user_id = ?;`;
+        await executeQueryPromise(queryClubMember, [accessTokenDecoded.id]);
+
+        const queryComments = `UPDATE post_recruit_comments SET user_id = ?, is_deleted = ? WHERE user_id = ?`;
+        await executeQueryPromise(queryComments, ["", 1, accessTokenDecoded.id]);
+
+        const queryMember = `DELETE FROM member WHERE user_id = ?;`;
+        await executeQueryPromise(queryMember, [accessTokenDecoded.id]);
+
+        resData.success = true;
+        resData.msg = '회원탈퇴에 성공 하였습니다.';
+        logout(req, res);
+        res.status(200).json(resData);
+    } catch (error) {
+        await executeQueryPromise('ROLLBACK');
+        resData.success = false;
+        resData.msg = '비밀번호 확인중 에러가 발생했습니다.';
+        console.error('비밀번호 확인중 에러가 발생했습니다.', error);
+        res.status(500).json(resData);
+    }
+}
+
+function logout(req, res) {
+    res.cookie('accessToken', '');
+    res.cookie('refreshToken', '');
+}
+
+module.exports = {
+    deleteAccount,
+    checkPw,
+}

--- a/app/src/controllers/register.ctrl.js
+++ b/app/src/controllers/register.ctrl.js
@@ -24,7 +24,6 @@ const userIdCheck = (req, res, next) => {
                 conn.release();
                 if (err) return handleDBError(err, conn);
                 
-                console.log(`해당 userId가 ${result[0].count > 0 ? "존재합니다." : "존재하지 않습니다."}`);
                 req.isAvailable = result[0].count > 0;
                 next();
             }

--- a/app/src/routes/users-profile.route.js
+++ b/app/src/routes/users-profile.route.js
@@ -4,6 +4,7 @@ const { checkAndFetchUserProfile, updateUserProfile } = require("../controllers/
 const { getUserProfile } = require("../controllers/profileCtrollers/profileView.ctrl");
 const { setChangePassword } = require("../controllers/profileCtrollers/profileChangePw.ctrl");
 const { verifyToken } = require('../controllers/tokenControllers/token.ctrl');
+const { deleteAccount, checkPw } = require('../controllers/profileCtrollers/profileDeleteAccount.ctrl');
 
 router.get("/users-profile", verifyToken, (req, res) => {
   res.render("users-profile");
@@ -16,5 +17,9 @@ router.post("/update-user-profile", updateUserProfile);
 router.get("/check-profile-existence", checkAndFetchUserProfile);
 
 router.post("/setChangePassword", setChangePassword);
+
+router.post("/api/account/check/pw", checkPw)
+
+router.delete("/api/delete/account/check/pw", deleteAccount);
 
 module.exports = router;

--- a/app/src/views/assets/js/profile/profile_delete_account.js
+++ b/app/src/views/assets/js/profile/profile_delete_account.js
@@ -1,0 +1,83 @@
+const openConfirmModalBtn = document.getElementById('deleteAccountForm');
+openConfirmModalBtn.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const pw = document.getElementById('passwordConfirmation').value;
+    const checkingPw = await checkPw(pw);
+    if(!checkingPw){
+        return;
+    }
+    const modal = new bootstrap.Modal(document.getElementById('confirmModal'));
+    modal.show();
+});
+
+async function checkPw(pw){
+    try {
+        const response = await fetch('/api/account/check/pw', {
+            method:'POST',
+            body: JSON.stringify({pw}),
+            headers: {
+                'Content-Type': 'Application/json',
+            },
+        });
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        if(!data.success){
+            alert(data.msg);
+        }
+        return data.success;
+    } catch (error) {
+        console.error(`에러가 발생했습니다. ${error}`);
+        alert('회원 정보를 확인하는데 에러가 발생했습니다.');
+        window.location.reload();
+    }
+}
+
+async function deleteAccount(pw){
+    try {
+        const response = await fetch('/api/delete/account/check/pw', {
+            method:'DELETE',
+            body: JSON.stringify({pw}),
+            headers: {
+                'Content-Type': 'Application/json',
+            },
+        });
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        if(!data.success){
+            alert(data.msg);
+            window.location.reload();
+            return;
+        }
+        alert(data.msg);
+        window.location.href = "/";
+    } catch (error) {
+        console.error(`에러가 발생했습니다. ${error}`);
+        alert('회원 정보를 확인하는데 에러가 발생했습니다.');
+        window.location.reload();
+    }
+}
+
+const confirmInput = document.getElementById('confirmInput');
+confirmInput.addEventListener('input', function () {
+    const input = this.value.trim();
+    const confirmBtn = document.getElementById('confirmBtn');
+    const confirmError = document.getElementById('confirmError');
+
+    if (input.toLowerCase() === '회원탈퇴') {
+        confirmBtn.removeAttribute('disabled');
+        confirmError.style.display = 'none';
+    } else {
+        confirmBtn.setAttribute('disabled', true);
+        confirmError.style.display = 'block';
+    }
+});
+
+const confirmBtn = document.getElementById('confirmBtn');
+confirmBtn.addEventListener('click', async () => {
+    const pw = document.getElementById('passwordConfirmation').value;
+    await deleteAccount(pw);
+});

--- a/app/src/views/ejs-file/users-profile.ejs
+++ b/app/src/views/ejs-file/users-profile.ejs
@@ -67,6 +67,10 @@
                       변경</button>
                   </li>
 
+                  <li class="nav-item">
+                    <button class="nav-link" data-bs-toggle="tab" data-bs-target="#delete-account-tab">회원탈퇴</button>
+                  </li>
+
                 </ul>
                 <div class="tab-content pt-2">
 
@@ -284,8 +288,34 @@
                       </div>
                     </form><!-- End Change Password Form -->
                   </div>
+                  
+                  <!-- 회원탈퇴 -->
+                  <div class="tab-pane fade" id="delete-account-tab">
+                    <h5 class="card-title"><회원 탈퇴></h5>
+                    <p>정말로 회원 탈퇴를 하시겠습니까? 탈퇴 후에는 복구할 수 없습니다.</p>
+                    
+                    <!-- 비밀번호 확인 필드 -->
+                    <form id="deleteAccountForm">
+                      <div class="mb-3">
+                        <label for="passwordConfirmation" class="form-label">비밀번호를 입력하세요</label>
+                        <input type="password" class="form-control" id="passwordConfirmation" name="passwordConfirmation" placeholder="비밀번호" required>
+                      </div>
+                      
+                      <!-- 탈퇴 확인 체크박스 -->
+                      <div class="mb-3 form-check">
+                        <input type="checkbox" class="form-check-input" id="confirmDeleteCheckbox" required>
+                        <label class="form-check-label" for="confirmDeleteCheckbox">위 내용을 확인하였으며, 탈퇴를 진행합니다.</label>
+                      </div>
+                      
+                      <!-- 안내 메시지 -->
+                      <p class="text-danger">탈퇴한 후에는 복구할 수 없습니다. 정말로 탈퇴하시겠습니까?</p>
+                      <div class="text-center">
+                        <button type="submit" id="deleteAccountBtn" class="btn btn-danger">회원 탈퇴하기</button>
+                      </div>
+                    </form>
+                  </div>
                 </div>
-              </div><!-- End Bordered Tabs -->
+              </div>
 
             </div>
           </div>
@@ -294,6 +324,26 @@
         </div>
       </section>
 
+      <!-- 회원탈퇴 확인 모달 -->
+      <div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="confirmModalLabel">회원 탈퇴 확인</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <p>회원 탈퇴를 진행하시려면 아래 입력창에 "회원탈퇴"라는 단어를 입력하세요.</p>
+              <input type="text" class="form-control mb-3" id="confirmInput" placeholder="회원탈퇴" required>
+              <p class="text-danger" id="confirmError" style="display: none;">입력된 단어가 일치하지 않습니다.</p>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+              <button type="button" id="confirmBtn" class="btn btn-danger" disabled>확인</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </main><!-- End #main -->
 
     <!-- ======= Footer ======= -->
@@ -320,6 +370,7 @@
       <script defer src="../assets/js/profile/profile_view.js"></script>
       <script defer src="../assets/js/profile/profile_edit.js"></script>
       <script defer src="../assets/js/profile/profile_change_pw.js"></script>
+      <script defer src="../assets/js/profile/profile_delete_account.js"></script>
 
       </body>
 


### PR DESCRIPTION
<회원 탈퇴 로직 구현 완료: 스팩>

1. 회원 탈퇴는 profile 페이지에 "회원탈퇴" 탭이 추가되었습니다.

2. 동아리 회장인경우 탈퇴가 불가능 합니다.

3. 비밀번호를 제대로 적고 모달에서 한번더 "회원탈퇴" 라는 문구를 다시 적어야지 탈퇴가 가능합니다.

4. member 테이블에 묶인 테이블에 ON DELETE CASCADE를 다 걸어서 관련된 테이블을 동시에 삭제합니다.

5. 그밖에 club_member, post_recruit_comments 테이블은 업데이트를 해야해서 트렌젝션을 사용하여 업데이트를 하였습니다.

6. 논리적인 상황을 대입해서 최대한 모든 데이터를 삭제 하도록 하였습니다. (클럽 소유의 데이터는 삭제 안함. / ex. 동아리 홍보 게시글)

7. 회원이 탈퇴되면 해당 로그인 쿠키가 모두 초기화 되며 로그아웃 되고 메인 화면으로 나가집니다.
![회원탈퇴 탭](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/23ee26d7-1b9b-4a20-8f15-fa4d5896a385)
![회원탈퇴 모달](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/aeacddb9-40f6-4d31-80b0-cff3cb7d1a4c)
![회원탈퇴 완료](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/689676e6-4422-45ce-b7ee-48e509cc2c45)
