### PR TITLE
동아리 삭제 로직 구현 완료

### DIFF
--- a/app/src/controllers/clubAdminControllers/clubDelete.ctrl.js
+++ b/app/src/controllers/clubAdminControllers/clubDelete.ctrl.js
@@ -1,5 +1,6 @@
 const { executeQueryPromise } = require("../../config/database.func");
 const { getTokenDecode } = require("../../controllers/tokenControllers/token.ctrl");
+const bcrypt = require("bcrypt");
 
 const thisClubOwnerCheck = async (req, res) => {
     const resData = {};
@@ -16,7 +17,7 @@ const thisClubOwnerCheck = async (req, res) => {
             return;
         }
         resData.success = true;
-        resData.haslogClubOwner = true;
+        resData.hasClubOwner = true;
         res.status(200).json(resData);
     } catch (error) {
         console.error(`해당 동아리 대표인지를 체크중 에러발생: ${error}`);
@@ -25,6 +26,64 @@ const thisClubOwnerCheck = async (req, res) => {
     }
 }
 
+const checkClubOwnerPw = async (req, res) => {
+    const resData = {};
+    try {
+        const { pw, category } = req.body;
+        const accessTokenDecoded = await getTokenDecode(req, res);
+
+        const getClubOwnerIdQuery = `SELECT club_owner FROM club WHERE category = ?;`;
+        const clubOwnerId = await executeQueryPromise(getClubOwnerIdQuery, [category]);
+        
+        const getUserData = `SELECT * FROM member WHERE user_id = ?;`;
+        const userData = await executeQueryPromise(getUserData, [accessTokenDecoded.id]);
+
+        if(clubOwnerId[0].club_owner !== userData[0].user_id){
+            resData.success = false;
+            resData.msg = '동아리 회장과 로그인된 ID가 다릅니다.';
+            res.status(200).json(resData);
+            return;
+        }
+
+        const isMatch = await bcrypt.compare(pw, userData[0].user_pw);
+        
+        if (!isMatch) {
+            resData.success = false;
+            resData.msg = '비밀번호를 다시 확인해주세요.';
+            res.status(200).json(resData);
+            return;
+        }
+
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리 삭제를 위한 비밀번호 조회중 에러 발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const deleteClub = async (req, res) => {
+    const resData = {};
+    try {
+        const { category } = req.body;
+        const accessTokenDecoded = await getTokenDecode(req, res);
+        
+        const query = `DELETE FROM club WHERE club_owner = ? AND category = ?;`;
+        await executeQueryPromise(query, [accessTokenDecoded.id, category]);
+
+        resData.success = true;
+        resData.msg = `동아리를 삭제 하였습니다!`;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리를 삭제하는 쿼리 진행중 에러 발생: ${error}`);
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
 module.exports = {
     thisClubOwnerCheck,
+    checkClubOwnerPw,
+    deleteClub,
 }

--- a/app/src/routes/pages-clubAdmin.route.js
+++ b/app/src/routes/pages-clubAdmin.route.js
@@ -5,7 +5,7 @@ const {verifyToken} = require("../controllers/tokenControllers/token.ctrl");
 const { clubApplication, clubApplicationStatusUpdate } = require("../controllers/clubAdminControllers/clubAdminApplication.ctrl");
 const { getClubRecruitPostList } = require("../controllers/clubAdminControllers/clubRecruitPost.ctrl");
 const { postClubNoticePost, getClubNoticePost, getDetailNotice, hasClubAdminAc, updateClubNotice, deleteClubNotice, clubOwnerCheck } = require("../controllers/clubAdminControllers/clubNoticePost.ctrl");
-const { thisClubOwnerCheck } = require("../controllers/clubAdminControllers/clubDelete.ctrl");
+const { thisClubOwnerCheck, checkClubOwnerPw, deleteClub } = require("../controllers/clubAdminControllers/clubDelete.ctrl");
 
 // 회원 목록을 가져오는 라우터
 router.get("/Page-clubAdmin", verifyToken, clubAdminController.isClubMember, clubAdminController.getClubMember);
@@ -45,5 +45,11 @@ router.get('/api/club/owner/check', clubOwnerCheck);
 
 //현재 로그인한 사람이 해당 동아리의 대표인지 확인하는 API
 router.get('/api/thisClubOwnerCheck/get', thisClubOwnerCheck);
+
+//동아리 삭제에 관한 API
+router.post('/api/club/owner/check/pw/post', checkClubOwnerPw);
+
+//동아리 삭제 API
+router.delete('/api/delete/club', deleteClub);
 
 module.exports = router;

--- a/app/src/views/assets/js/pagesAdmin/admin_edit.js
+++ b/app/src/views/assets/js/pagesAdmin/admin_edit.js
@@ -438,13 +438,13 @@ function pageSplit() {
                     clubIntroLi.className = 'nav-item';
 
                     const joinList = document.createElement('button');
-                    joinList.className = 'nav-link';
+                    joinList.className = 'nav-link join-list-tab';
                     joinList.setAttribute('data-bs-toggle', 'tab');
                     joinList.setAttribute('data-bs-target', '#profile-settings');
                     joinList.innerText = '가입 신청 현황';
 
                     const clubIntroductionEdit = document.createElement('button');
-                    clubIntroductionEdit.className = 'nav-link';
+                    clubIntroductionEdit.className = 'nav-link club-introduction-edit-tab';
                     clubIntroductionEdit.setAttribute('data-bs-toggle', 'tab');
                     clubIntroductionEdit.setAttribute('data-bs-target', '#clubIntroductionEdit');
                     clubIntroductionEdit.innerText = '동아리 소개 편집';

--- a/app/src/views/assets/js/pagesAdmin/delete_club.js
+++ b/app/src/views/assets/js/pagesAdmin/delete_club.js
@@ -1,3 +1,21 @@
+let tabsLoaded = false;
+
+function checkTabsLoaded() {
+    if (tabsLoaded) return;
+    const joinList = document.querySelector('.nav-link.join-list-tab');
+    const clubIntroEdit = document.querySelector('.nav-link.club-introduction-edit-tab');
+    if (joinList && clubIntroEdit) {
+        createDeleteClubTab();
+        tabsLoaded = true;
+    } else {
+        setTimeout(checkTabsLoaded, 100);
+    }
+}
+
+function init() {
+    checkTabsLoaded();
+}
+
 function getCategory() {
     const urlParams = new URLSearchParams(window.location.search);
     const category = urlParams.get('query');
@@ -19,6 +37,7 @@ async function thisClubOwnerCheck(){
             throw new Error('네트워크 응답이 올바르지 않습니다.');
         }
         const data = await response.json();
+        return data;
     } catch (error) {
         alert(`에러가 발생했습니다. ${error}`);
         console.error(`에러가 발생했습니다. ${error}`);
@@ -26,6 +45,178 @@ async function thisClubOwnerCheck(){
     }
 }
 
+function createDeleteClubTab() {
+    const newLi = document.createElement('li');
+    newLi.className = 'nav-item';
+
+    const deleteClubTab = document.createElement('button');
+    deleteClubTab.className = 'nav-link';
+    deleteClubTab.setAttribute('data-bs-toggle', 'tab');
+    deleteClubTab.setAttribute('data-bs-target', '#clubDelete');
+    deleteClubTab.innerText = '동아리 삭제';
+    deleteClubTab.id = 'deleteClubTabBtn';
+
+    newLi.appendChild(deleteClubTab);
+    const parentUl = document.querySelector('.nav-tabs');
+    parentUl.appendChild(newLi);
+
+    const tabContent = document.createElement('div');
+    tabContent.className = 'tab-pane fade';
+    tabContent.id = 'clubDelete';
+
+    const title = document.createElement('h5');
+    title.className = 'card-title';
+    title.innerText = '<동아리 삭제>';
+
+    const paragraph = document.createElement('p');
+    paragraph.innerText = '정말로 동아리를 삭제하시겠습니까? 삭제 후에는 복구할 수 없습니다.';
+
+    const form = document.createElement('form');
+    form.id = 'deleteClubForm';
+
+    const divPassword = document.createElement('div');
+    divPassword.className = 'mb-3';
+
+    const labelPassword = document.createElement('label');
+    labelPassword.setAttribute('for', 'clubPasswordConfirmation');
+    labelPassword.className = 'form-label';
+    labelPassword.innerText = '비밀번호를 입력하세요';
+
+    const inputPassword = document.createElement('input');
+    inputPassword.type = 'password';
+    inputPassword.className = 'form-control';
+    inputPassword.id = 'clubPasswordConfirmation';
+    inputPassword.name = 'clubPasswordConfirmation';
+    inputPassword.placeholder = '비밀번호';
+    inputPassword.required = true;
+
+    const divCheckbox = document.createElement('div');
+    divCheckbox.className = 'mb-3 form-check';
+
+    const inputCheckbox = document.createElement('input');
+    inputCheckbox.type = 'checkbox';
+    inputCheckbox.className = 'form-check-input';
+    inputCheckbox.id = 'confirmClubDeleteCheckbox';
+    inputCheckbox.required = true;
+
+    const labelCheckbox = document.createElement('label');
+    labelCheckbox.className = 'form-check-label';
+    labelCheckbox.setAttribute('for', 'confirmClubDeleteCheckbox');
+    labelCheckbox.innerText = '위 내용을 확인하였으며, 동아리 삭제를 진행합니다.';
+
+    const warningText = document.createElement('p');
+    warningText.className = 'text-danger';
+    warningText.innerText = '동아리를 삭제한 후에는 복구할 수 없습니다. 정말로 삭제하시겠습니까?';
+
+    const buttonDiv = document.createElement('div');
+    buttonDiv.className = 'text-center';
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'submit';
+    deleteButton.id = 'deleteClubBtn';
+    deleteButton.className = 'btn btn-danger';
+    deleteButton.innerText = '동아리 삭제하기';
+
+    divPassword.appendChild(labelPassword);
+    divPassword.appendChild(inputPassword);
+
+    divCheckbox.appendChild(inputCheckbox);
+    divCheckbox.appendChild(labelCheckbox);
+
+    form.appendChild(divPassword);
+    form.appendChild(divCheckbox);
+    form.appendChild(warningText);
+    buttonDiv.appendChild(deleteButton);
+    form.appendChild(buttonDiv);
+
+    tabContent.appendChild(title);
+    tabContent.appendChild(paragraph);
+    tabContent.appendChild(form);
+
+    const tabContainer = document.querySelector('.tab-content');
+    tabContainer.appendChild(tabContent);
+}
+
+const deleteClubConfirmInput = document.getElementById('deleteClubConfirmInput');
+deleteClubConfirmInput.addEventListener('input', function () {
+    const input = this.value.trim();
+    const deleteClubConfirmBtn = document.getElementById('deleteClubConfirmBtn');
+    const deleteClubConfirmError = document.getElementById('deleteClubConfirmError');
+
+    if (input.toLowerCase() === '동아리삭제') {
+        deleteClubConfirmBtn.removeAttribute('disabled');
+        deleteClubConfirmError.style.display = 'none';
+    } else {
+        deleteClubConfirmBtn.setAttribute('disabled', true);
+        deleteClubConfirmError.style.display = 'block';
+    }
+});
+
+async function checkClubOwnerPw(){
+    try {
+        const category = getCategory();
+        const pw = document.getElementById('clubPasswordConfirmation').value;
+        const response = await fetch('/api/club/owner/check/pw/post', {
+            method: 'POST',
+            body: JSON.stringify({category, pw}),
+            headers: {
+                'Content-type': 'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        if(!data.success){
+            alert(data.msg);
+        }
+        return data.success;
+    } catch (error) {
+        console.error(`에러가 발생했습니다. ${error}`);
+        alert('비밀번호를 조회중 에러가 발생했습니다.');
+        window.location.reload();
+    }
+}
+
+document.getElementById('deleteClubConfirmBtn').addEventListener('click', async () => {
+    try {
+        const category = getCategory();
+        const response = await fetch('/api/delete/club', {
+            method: 'DELETE',
+            body: JSON.stringify({category}),
+            headers: {
+                'Content-Type': 'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        alert(data.msg);
+        window.location.href = "/";
+    } catch (error) {
+        console.error(`에러가 발생했습니다. ${error}`);
+        alert('동아리를 삭제하는데 실패하였습니다.');
+        window.location.reload();
+    }
+})
+
 document.addEventListener('DOMContentLoaded', async () => {
-    await thisClubOwnerCheck();
+    const {success, hasClubOwner} = await thisClubOwnerCheck();
+    if( success && hasClubOwner){
+        init();
+    }
+    const deleteClubForm = document.getElementById('deleteClubForm');
+    if(deleteClubForm){
+        deleteClubForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const isClubOwner = await checkClubOwnerPw();
+            if(isClubOwner){
+                const modal = new bootstrap.Modal(document.getElementById('clubDeleteConfirmModal'));
+                modal.show();
+            }
+        });
+    }
 })

--- a/app/src/views/ejs-file/page-club-profile/page-club-profile.ejs
+++ b/app/src/views/ejs-file/page-club-profile/page-club-profile.ejs
@@ -25,37 +25,37 @@
         </section>
     </div>
 
-<!-- 동아리 탈퇴 확인 모달 -->
-<div class="modal fade" id="clubResignationModal" tabindex="-1" aria-labelledby="clubResignationLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header bg-danger text-white">
-                <h5 class="modal-title" id="clubResignationLabel">동아리 탈퇴 확인</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="container-fluid">
-                    <div class="row">
-                        <div class="col-12">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h5 class="card-title">동아리 정보</h5>
-                                    <p class="card-text"><strong>동아리 이름:</strong> <span id="resignClubName">-</span></p>
-                                    <p class="card-text"><strong>소속:</strong> <span id="resignClubAffiliation">-</span></p>
+    <!-- 동아리 탈퇴 확인 모달 -->
+    <div class="modal fade" id="clubResignationModal" tabindex="-1" aria-labelledby="clubResignationLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header bg-danger text-white">
+                    <h5 class="modal-title" id="clubResignationLabel">동아리 탈퇴 확인</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="container-fluid">
+                        <div class="row">
+                            <div class="col-12">
+                                <div class="card">
+                                    <div class="card-body">
+                                        <h5 class="card-title">동아리 정보</h5>
+                                        <p class="card-text"><strong>동아리 이름:</strong> <span id="resignClubName">-</span></p>
+                                        <p class="card-text"><strong>소속:</strong> <span id="resignClubAffiliation">-</span></p>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <p>정말로 동아리에서 탈퇴하시겠습니까?<br>이 작업은 되돌릴 수 없습니다.</p>
                     </div>
-                    <p>정말로 동아리에서 탈퇴하시겠습니까?<br>이 작업은 되돌릴 수 없습니다.</p>
                 </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
-                <button id="clubResignationModalBtn" type="button" class="btn btn-danger">탈퇴하기</button>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                    <button id="clubResignationModalBtn" type="button" class="btn btn-danger">탈퇴하기</button>
+                </div>
             </div>
         </div>
     </div>
-</div>
 </main><!-- End #main -->
 
 <style>

--- a/app/src/views/ejs-file/pages-clubAdmin.ejs
+++ b/app/src/views/ejs-file/pages-clubAdmin.ejs
@@ -444,24 +444,45 @@
     </div>
 
     <!-- 공지사항 삭제 확인 모달 -->
-    <div class="modal fade" id="deleteNoticeModal" tabindex="-1" aria-labelledby="deleteModalLabel"
-    aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="deleteModalLabel">공지사항 삭제 확인</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                정말로 이 공지사항을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
-                <button id = "realDeleteBtn" type="button" class="btn btn-danger">삭제</button>
+    <div class="modal fade" id="deleteNoticeModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="deleteModalLabel">공지사항 삭제 확인</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    정말로 이 공지사항을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                    <button id="realDeleteBtn" type="button" class="btn btn-danger">삭제</button>
+                </div>
             </div>
         </div>
     </div>
-</div>
+
+    <!-- 동아리 삭제 확인 모달 -->
+    <div class="modal fade" id="clubDeleteConfirmModal" tabindex="-1" aria-labelledby="clubDeleteConfirmModalLabel"
+        aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="clubDeleteConfirmModalLabel">동아리 삭제 확인</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>동아리 삭제를 진행하시려면 아래 입력창에 "동아리삭제"라는 단어를 입력하세요.</p>
+                    <input type="text" class="form-control mb-3" id="deleteClubConfirmInput" placeholder="동아리삭제" required>
+                    <p class="text-danger" id="deleteClubConfirmError" style="display: none;">입력된 단어가 일치하지 않습니다.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                    <button type="button" id="deleteClubConfirmBtn" class="btn btn-danger" disabled>확인</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </main><!-- End #main -->
 
 <!-- ======= Footer ======= -->


### PR DESCRIPTION
<동아리 삭제 로직 구현 스팩>:

1. 동아리가 삭제되면 현재 있는 테이블 중에서 
club테이블에서 해당 row가 삭제되면서 외래키로 묶인 테이블에서 해당 category 데이터들이 모두 동시에 삭제됩니다.

2. 기본 스팩은 회원 탈퇴와 유사합니다.

3. 동아리 삭제는 여러명에게 영향이 가서 특히 더 꼼꼼하게 조건을 걸어가면서 작업 하였습니다.

4. 동아리 삭제는 동아리 관리 페이지에서 해당 동아리의 회장인 경우에만 "동아리 삭제" 탭이 생성 됩니다.

4-1. 삭제 방법은 회원 탈퇴와 동일 합니다. (비밀번호, 한번더 확인 문구 입력)

5. 동아리 회장이 아닌경우에는 아에 탭 자체가 만들어지지 않아서 다른 유저는 절때 접근이 불가능 합니다.

