### PR TITLE
동아리 관리, 동아리 프로필, 동아리 소개 페이지 에서 좋아요 기능 구현완료

### DIFF
--- a/app/src/controllers/clubIntroductionControllers/clubLikes.ctrl.js
+++ b/app/src/controllers/clubIntroductionControllers/clubLikes.ctrl.js
@@ -1,0 +1,97 @@
+const { executeQueryPromise } = require("../../config/database.func");
+const { getTokenDecode } = require("../../controllers/tokenControllers/token.ctrl");
+
+const getClubLikes = async (req, res) => {
+    const resData = {};
+    try {
+        const { id } = await getTokenDecode(req, res);
+        const query = `SELECT * FROM club_likes WHERE user_id = ?;`;
+        const clubLikes = await executeQueryPromise(query, [id]);
+        resData.clubLikes = clubLikes;
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리들의 "좋아요" 조회중 에러 발생: ${error}`)
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const addClubLike = async (req, res) => {
+    const resData = {};
+    try {
+        const { category } = req.body;
+        const { id } = await getTokenDecode(req, res);
+        const query = `INSERT INTO club_likes (user_id, category) VALUES (?, ?);`;
+        await executeQueryPromise(query, [id, category]);
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`특정 동아리의 "좋아요" 추가중 에러 발생: ${error}`)
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const deleteClubLike = async (req, res) => {
+    const resData = {};
+    try {
+        const { category } = req.body;
+        const { id } = await getTokenDecode(req, res);
+        const query = `DELETE FROM club_likes WHERE user_id = ? AND category = ?;`;
+        await executeQueryPromise(query, [id, category]);
+        resData.success = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`특정 동아리의 "좋아요" 삭제중 에러 발생: ${error}`)
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const getClubLike = async (req, res) => {
+    const resData = {};
+    try {
+        const category = req.query.category;
+        const { id } = await getTokenDecode(req, res);
+        const query = `SELECT * FROM club_likes WHERE user_id = ? AND category = ?;`;
+        const clubLike = await executeQueryPromise(query, [id, category]);
+        if(clubLike.length === 0){
+            resData.success = true;
+            resData.isClubLike = false;
+            res.status(200).json(resData);
+            return;
+        }
+        resData.success = true;
+        resData.isClubLike = true;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`특정 동아리의 "좋아요" 조회중 에러 발생: ${error}`)
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+const getClubLikesCount = async (req, res) =>{
+    const resData = {};
+    try {
+        const category = req.query.category;
+        const query = `SELECT * FROM club_likes WHERE category = ?;`;
+        const clubLikes = await executeQueryPromise(query, [category]);
+        resData.success = true;
+        resData.clubLikesCount = clubLikes.length;
+        res.status(200).json(resData);
+    } catch (error) {
+        console.error(`동아리의 "좋아요" 개수를 조회중 에러 발생: ${error}`)
+        resData.success = false;
+        res.status(500).json(resData);
+    }
+}
+
+module.exports = {
+    getClubLikes,
+    addClubLike,
+    deleteClubLike,
+    getClubLike,
+    getClubLikesCount,
+}

--- a/app/src/routes/clubIntroduction/pages-clubIntroduction.route.js
+++ b/app/src/routes/clubIntroduction/pages-clubIntroduction.route.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { getClubIntroduction, saveClubIntroEdit,getClubDataForGraph } = require("../../controllers/clubIntroductionControllers/clubIntroduction.ctrl")
+const { getClubLikes, addClubLike, deleteClubLike, getClubLike, getClubLikesCount } = require("../../controllers/clubIntroductionControllers/clubLikes.ctrl");
 
 router.get("/club-introduction", (req, res) => {
     res.render("page-club-introduction/page-club-introduction");
@@ -11,5 +12,15 @@ router.get("/api/club-introduction-data/get", getClubIntroduction);
 router.get("/api/club-data/get", getClubDataForGraph);
 
 router.put("/api/club/intro/edit/save", saveClubIntroEdit);
+
+router.get("/api/club/like", getClubLikes);
+
+router.post("/api/club/like/add", addClubLike);
+
+router.delete("/api/club/like/delete", deleteClubLike);
+
+router.get("/api/club/like/one/get", getClubLike);
+
+router.get("/api/club/likes/count", getClubLikesCount);
 
 module.exports = router;

--- a/app/src/views/assets/js/clubProfile/clubProfile.js
+++ b/app/src/views/assets/js/clubProfile/clubProfile.js
@@ -1,13 +1,34 @@
 // assets/js/main.js
 
+async function getClubLikesCount(category){
+    try {
+        const response = await fetch(`/api/club/likes/count?category=${category}`, {
+            method:"GET",
+            headers: {
+                "Content-Type": "Application/json",
+            },
+        });
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+
+        const data = await response.json();
+        const count = data.clubLikesCount;
+        return count;
+    } catch (error) {
+        console.error(`해당 동아리의 좋아요 정보를 받아오던중 에러발생: ${error}`);
+        alert(`해당 동아리의 좋아요 정보를 받아오던중 에러발생 ${error}`);
+        window.location.reload();
+    }
+}
+
 // 카드를 생성하는 함수
-function createClubCard(club) {
+async function createClubCard(club) {
     const { twitter_link, facebook_link, instagram_link } = club;
     const twitterLink = twitter_link || '';
     const facebookLink = facebook_link || '';
     const instagramLink = instagram_link || '';
 
-    // const setDisplayTwitter = twitterLink
     let setDisplayTwitter = "none";
     let setDisplayFacebook = "none";
     let setDisplayInstagram = "none";
@@ -22,6 +43,7 @@ function createClubCard(club) {
         setDisplayInstagram = "inline-block"
     }
 
+    const count = await getClubLikesCount(club.category);
     return `
     <div class="col-md-4 mb-4 team-card">
         <a href="/Page-clubAdmin?query=${club.category}" style="margin: auto;">
@@ -34,6 +56,9 @@ function createClubCard(club) {
                 <a href=${twitterLink} id = twitterBtn-${club.category} class="btn btn-outline-primary me-2 twitter-link-${club.category}" target="_blank" style="display: ${setDisplayTwitter}"><i class="bi bi-twitter"></i></a>
                 <a href=${facebookLink} id = facebookBtn-${club.category} class="btn btn-outline-primary me-2 facebook-link-${club.category}" target="_blank" style="display: ${setDisplayFacebook}"><i class="bi bi-facebook"></i></a>
                 <a href=${instagramLink} id = instagramBtn-${club.category} class="btn btn-outline-primary me-2 instagram-link-${club.category}" target="_blank" style="display: ${setDisplayInstagram}"><i class="bi bi-instagram"></i></a>
+                <a href="#" id="heartBtn-${club.category}" class="btn btn-outline-danger me-2" onclick="handleHeartClick(event, '${club.category}')"><i class="bi bi-heart"></i>
+                    <span id="likeCount-${club.category}">${count}</span>
+                </a>
                 </div>
                 <div class="text-center mt-3">
                     <button class="clubResignationBtn btn btn-danger club-resignation-${club.category}" data-bs-toggle="modal" data-bs-target="#clubResignationModal">탈퇴하기</button>
@@ -43,6 +68,106 @@ function createClubCard(club) {
         </a>
     </div>
     `;
+}
+
+async function isClubLike(){
+    try {
+        const response = await fetch('/api/club/like', {
+            method: 'GET',
+            headers: {
+                'Content-Type':'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+
+        const data = await response.json();
+        data.clubLikes.forEach(category => {
+            const heartIcon = document.querySelector(`#heartBtn-${category.category} i`);
+            if(heartIcon){
+                heartIcon.classList.remove('bi-heart');
+                heartIcon.classList.add('bi-heart-fill');
+            }
+        })
+    } catch (error) {
+        console.error(`"좋아요" 정보를 불러오던중 에러 발생: ${error}`);
+        alert(`"좋아요" 정보를 가져오지 못했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+async function addClubLike(category){
+    try {
+        const response = await fetch('/api/club/like/add', {
+            method: 'POST',
+            body: JSON.stringify({category}),
+            headers: {
+                'Content-Type':'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+    } catch (error) {
+        console.error(`"좋아요"를 하던중 에러 발생: ${error}`);
+        alert(`"좋아요"를 추가하지 못했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+async function deleteClubLike(category){
+    try {
+        const response = await fetch('/api/club/like/delete', {
+            method: 'DELETE',
+            body: JSON.stringify({category}),
+            headers: {
+                'Content-Type':'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+    } catch (error) {
+        console.error(`"좋아요"를 제거하던중 에러 발생: ${error}`);
+        alert(`"좋아요"를 제거하지 못했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+async function handleHeartClick(event, category){
+    event.preventDefault();
+    const heartIcon = document.querySelector(`#heartBtn-${category} i`);
+    const isFilled = heartIcon.classList.contains('bi-heart-fill');
+
+    if (isFilled) {
+        try {
+            await deleteClubLike(category);
+            heartIcon.classList.remove('bi-heart-fill');
+            heartIcon.classList.add('bi-heart');
+            const count = await getClubLikesCount(category);
+            document.getElementById(`likeCount-${category}`).innerText = count;
+        } catch (error) {
+            console.error(`좋아요를 제거하는 중 오류 발생: ${error}`);
+            alert(`좋아요를 제거하지 못했습니다. ${error}`);
+        }
+    } else {
+        try {
+            await addClubLike(category);
+            heartIcon.classList.remove('bi-heart');
+            heartIcon.classList.add('bi-heart-fill');
+            const count = await getClubLikesCount(category);
+            document.getElementById(`likeCount-${category}`).innerText = count;
+        } catch (error) {
+            console.error(`좋아요를 추가하는 중 오류 발생: ${error}`);
+            alert(`좋아요를 추가하지 못했습니다. ${error}`);
+        }
+    }
 }
 
 async function fetchAndDisplayClubs() {
@@ -59,10 +184,10 @@ async function fetchAndDisplayClubs() {
         const data = await response.json();
         const clubsContainer = document.getElementById('container');
         if (data && data.clubs && data.clubs.length > 0) {
-            data.clubs.forEach(club => {
-                const cardHtml = createClubCard(club);
+            for (const club of data.clubs) {
+                const cardHtml = await createClubCard(club);
                 clubsContainer.insertAdjacentHTML('beforeend', cardHtml);
-            });
+            }
         } else {
             displayNoClubMessage();
         }
@@ -182,6 +307,7 @@ async function displayNoClubMessage() {
 // DOMContentLoaded 이벤트 핸들러에서 fetchAndDisplayClubs 함수 호출
 document.addEventListener('DOMContentLoaded', async () => {
     await fetchAndDisplayClubs();
+    await isClubLike();
 
     document.querySelectorAll('.clubResignationBtn').forEach(button => {
         button.addEventListener('click', async (event) => {

--- a/app/src/views/assets/js/pagesAdmin/admin_club_like.js
+++ b/app/src/views/assets/js/pagesAdmin/admin_club_like.js
@@ -1,0 +1,163 @@
+function getCategory() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const category = urlParams.get('query');
+
+    return category;
+}
+
+async function addClubLike(category){
+    try {
+        const response = await fetch('/api/club/like/add', {
+            method: 'POST',
+            body: JSON.stringify({category}),
+            headers: {
+                'Content-Type':'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+    } catch (error) {
+        console.error(`"좋아요"를 하던중 에러 발생: ${error}`);
+        alert(`"좋아요"를 추가하지 못했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+async function deleteClubLike(category){
+    try {
+        const response = await fetch('/api/club/like/delete', {
+            method: 'DELETE',
+            body: JSON.stringify({category}),
+            headers: {
+                'Content-Type':'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+    } catch (error) {
+        console.error(`"좋아요"를 제거하던중 에러 발생: ${error}`);
+        alert(`"좋아요"를 제거하지 못했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+async function isLogin(){
+    try {
+        const response = await fetch('/isLogin', {
+            method:'GET',
+            headers: {
+                'Content-Type': 'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const { isLogin } = await response.json();
+        return isLogin;
+    } catch (error) {
+        console.error(`로그인 정보를 확인중 에러발생: ${error}`);
+        alert(`로그인 정보를 확인중 에러발생 ${error}`);
+        window.location.reload();
+    }
+}
+
+async function getClubLikesCount(){
+    try {
+        const category = getCategory();
+        const response = await fetch(`/api/club/likes/count?category=${category}`, {
+            method:"GET",
+            headers: {
+                "Content-Type": "Application/json",
+            },
+        });
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+
+        const data = await response.json();
+        const count = data.clubLikesCount;
+        document.getElementById('likeCount').innerText = count;
+    } catch (error) {
+        console.error(`해당 동아리의 좋아요 정보를 받아오던중 에러발생: ${error}`);
+        alert(`해당 동아리의 좋아요 정보를 받아오던중 에러발생 ${error}`);
+        window.location.reload();
+    }
+}
+
+document.getElementById('clubHeartBtn').addEventListener('click', async (event) => {
+    const loginCheck = await isLogin();
+    if(!loginCheck){
+        window.location.href = "/pages-login";
+        return ;
+    }
+    await handleHeartClick(event);
+})
+
+async function handleHeartClick(event){
+    event.preventDefault();
+    const category = getCategory();
+    const heartIcon = document.querySelector(`#clubHeartBtn i`);
+    const isFilled = heartIcon.classList.contains('bi-heart-fill');
+
+    if (isFilled) {
+        try {
+            await deleteClubLike(category);
+            heartIcon.classList.remove('bi-heart-fill');
+            heartIcon.classList.add('bi-heart');
+            await getClubLikesCount();
+        } catch (error) {
+            console.error(`좋아요를 제거하는 중 오류 발생: ${error}`);
+            alert(`좋아요를 제거하지 못했습니다. ${error}`);
+        }
+    } else {
+        try {
+            await addClubLike(category);
+            heartIcon.classList.remove('bi-heart');
+            heartIcon.classList.add('bi-heart-fill');
+            await getClubLikesCount();
+        } catch (error) {
+            console.error(`좋아요를 추가하는 중 오류 발생: ${error}`);
+            alert(`좋아요를 추가하지 못했습니다. ${error}`);
+        }
+    }
+}
+
+async function isClubLike(){
+    try {
+        const category = getCategory();
+        const response = await fetch(`/api/club/like/one/get?category=${category}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type':'Application/json',
+            },
+        });
+
+        if(!response.ok){
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+
+        const data = await response.json();        
+        if(data.isClubLike){
+            const heartIcon = document.querySelector(`#clubHeartBtn i`);
+            heartIcon.classList.remove('bi-heart');
+            heartIcon.classList.add('bi-heart-fill');
+        }
+        } catch (error) {
+        console.error(`"좋아요" 정보를 불러오던중 에러 발생: ${error}`);
+        alert(`"좋아요" 정보를 가져오지 못했습니다. ${error}`);
+        window.location.reload();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    await getClubLikesCount();
+    const loginCheck = await isLogin();
+    if(loginCheck){
+        await isClubLike();
+    }
+})

--- a/app/src/views/assets/js/post/index.postDashboard.js
+++ b/app/src/views/assets/js/post/index.postDashboard.js
@@ -177,10 +177,10 @@ function createCardClosed(data) {
                     </div>
                 </div>
                 <div style="position: relative;">
-               <div class="d-inline-flex align-items-center" id="heartSection_${data.post_number}" style="position: absolute; bottom: 0; right: 0;">
-                 <i class="fas fa-heart" style="margin-right: 5px;" id="dead_${data.post_number}"></i>
-                  <span class="badge rounded-pill bg-secondary" style="font-size: 12px;">${data.like_count}</span>
-                </div>
+                    <div class="d-inline-flex align-items-center" id="heartSection_${data.post_number}" style="position: absolute; bottom: 0; right: 0;">
+                        <i class="fas fa-heart" style="margin-right: 5px;" id="dead_${data.post_number}"></i>
+                        <span class="badge rounded-pill bg-secondary" style="font-size: 12px;">${data.like_count}</span>
+                    </div>
                 </div>
             </a>
         </div>

--- a/app/src/views/ejs-file/page-club-introduction/page-club-introduction.ejs
+++ b/app/src/views/ejs-file/page-club-introduction/page-club-introduction.ejs
@@ -19,6 +19,9 @@
         <div class="row">
           <div class="col-xl-4">
             <div class="card">
+              <a href="#" id="clubHeartBtn" class="btn btn-outline-danger position-absolute top-0 end-0 m-2"><i class="bi bi-heart"></i>
+                <span id="likeCount">0</span>
+              </a>
               <div class="card-body profile-card pt-4 d-flex flex-column align-items-center">
                 <img src="assets/img/hs-logo.png" alt="Profile" class="rounded-circle">
                 <h2 id="clubName">동아리명 : -</h2>
@@ -135,6 +138,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
 
       <!--Client JS File-->
+      <script defer src="../../assets/js/pagesAdmin/admin_club_like.js"></script>
       <script defer src="../../assets/js/clubIntroPage/clubs_introduction.js"></script>
       <script defer src="../../assets/js/clubIntroPage/clubIntroRecruitTab.js"></script>
 

--- a/app/src/views/ejs-file/pages-clubAdmin.ejs
+++ b/app/src/views/ejs-file/pages-clubAdmin.ejs
@@ -20,6 +20,9 @@
         <div class="row">
             <div class="col-xl-4">
                 <div class="card">
+                    <a href="#" id="clubHeartBtn" class="btn btn-outline-danger position-absolute top-0 end-0 m-2"><i class="bi bi-heart"></i>
+                        <span id="likeCount">0</span>
+                    </a>
                     <div class="card-body profile-card pt-4 d-flex flex-column align-items-center">
                         <img src="assets/img/hs-logo.png" alt="Profile" class="rounded-circle">
                         <h2>동아리명 : <%= club.club_name%> </h2>
@@ -519,6 +522,7 @@
 <script defer src="../assets/js/pagesAdmin/club_notice_tab.js"></script>
 <script defer src="../assets/js/pagesAdmin/club_introduction_tab.js"></script>
 <script defer src="../assets/js/pagesAdmin/delete_club.js"></script>
+<script defer src="../assets/js/pagesAdmin/admin_club_like.js"></script>
 
 </body>
 


### PR DESCRIPTION
<동아리 "좋아요" 기능 스팩>:

1. club_likes 테이블이 추가되었습니다.

2. 동아리 관리 페이지, 동아리 프로필 페이지, 동아리 소개 페이지에서 해당 동아리 "좋아요" 기능을 사용할 수 있습니다.

3. 로그인이 되지 않은 상태에서 좋아요를 누르면 바로 로그인 페이지로 랜더링 됩니다.

4. 좋아요를 누르면 해당 부분의 하트가 채워진 하트로 변경되고 좋아요를 안누르면 빈 하트가 보입니다.

5. 현재 해당 동아리에 좋아요가 몇개가 눌렸는지도 확인 가능합니다.

![동아리 소개 페이지](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/7f5113a1-2a6b-4f41-b435-20044de1054b)
![동아리 프로필 페이지](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/49cfb7a0-912d-4dce-af4e-61e22d7db744)
![동아리 관리 페이지](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/c4f3d11c-738b-4ea1-aeb5-28d59dd21ab5)
