### PR TITLE
클라우드를 통한 유저 프로필 세팅 완료

### DIFF
--- a/app/src/controllers/profileCtrollers/profileEdit.ctrl.js
+++ b/app/src/controllers/profileCtrollers/profileEdit.ctrl.js
@@ -32,7 +32,7 @@ const updateUserProfile = async (req, res) => {
     try {
         const accessTokenDecoded = await getTokenDecode(req, res);
         const {
-            profile_img_route, //프로필 이미지 아직 미구현
+            profile_img_route,
             about,
             joined_clubs,
             twitter_link,
@@ -54,7 +54,7 @@ const updateUserProfile = async (req, res) => {
             instagram_link = VALUES(instagram_link)`,
             [
                 user_id,
-                profile_img_route, //프로필 이미지 아직 미구현
+                profile_img_route,
                 about,
                 joined_clubs,
                 twitter_link,

--- a/app/src/controllers/searchCtrollers/searchUser.ctrl.js
+++ b/app/src/controllers/searchCtrollers/searchUser.ctrl.js
@@ -83,10 +83,30 @@ const searchResult = async (req, res) => {
             return res.json({ success: false });
         }
         const searchMemberResult = await searchMember(searchQuery);
-        res.json(searchMemberResult);
+        
+        const fetchProfileImages = searchMemberResult.result.map(async (user) => {
+            const profileImage = await fetchProfileImage(user.user_id);
+            return { ...user, profile_img_route: profileImage };
+        });
+
+        const results = await Promise.all(fetchProfileImages);
+        // res.json({ success: true, result: results });
+        res.json(results);
     } catch (error) {
         res.status(500).json({ success: false, error: error.message });
     }
+}
+
+// 사용자의 profile_img_route를 가져오는 함수
+async function fetchProfileImage(userId) {
+    const profileImage = await executeQueryPromise(
+        "SELECT profile_img_route FROM user_profile WHERE user_id = ?",
+        [userId]
+    );
+    if(profileImage.length === 0){
+        return 'https://res.cloudinary.com/dtn8eum07/image/upload/v1716351281/iz2btsipfkgqkxcckx1f.png';
+    }
+    return profileImage[0].profile_img_route;
 }
 
 module.exports = {

--- a/app/src/views/assets/js/profile/headerProfileImg.js
+++ b/app/src/views/assets/js/profile/headerProfileImg.js
@@ -1,0 +1,51 @@
+async function checkLogin() {
+    try {
+        const response = await fetch('/isLogin', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        if (!response.ok) {
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        return data.isLogin;
+    } catch (err) {
+        alert("에러가 발생했습니다.");
+        console.error(err);
+        window.location.href = "/";
+    }
+}
+
+async function getUserProfile(){
+    try {
+        const response = await fetch('/getUserProfileData', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+
+        const data = await response.json();
+        if (data.success) {
+            const userProfile = data.userProfile;
+            document.getElementById('header-profile-img').src = userProfile.profile_img_route;
+        }
+    } catch (error) {
+        console.log(`프로필 이미지 가져오던중 에러 발생: ${error}`);
+        alert(`프로필 이미지 가져오던중 에러 발생: ${error}`);
+        window.location.href = "/error-page";
+    }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const isLogin = await checkLogin();
+    if(isLogin){
+        await getUserProfile();
+    }
+})

--- a/app/src/views/assets/js/profile/profile_view.js
+++ b/app/src/views/assets/js/profile/profile_view.js
@@ -22,6 +22,7 @@ document.addEventListener('DOMContentLoaded', function () {
     .then(data => {
         if (data.success) {
             const userProfile = data.userProfile;
+            document.getElementById('profile-img').src = userProfile.profile_img_route;
             document.getElementById('viewAbout').innerText = userProfile.about;
             document.getElementById('joinedClubs').innerText = convertToNewLines(userProfile.joined_clubs);
             

--- a/app/src/views/assets/js/search/user_search_profile.js
+++ b/app/src/views/assets/js/search/user_search_profile.js
@@ -65,6 +65,14 @@ function setJoinedClubs(userProfileData){
     document.getElementById('joinedClubs').innerText = convertToNewLines(userProfileData.profile.joined_clubs);
 }
 
+//프로필 사진 설정
+function setUserProfileImg(userProfileData){
+    if(!userProfileData.hasProfile){
+        return;
+    }
+    document.getElementById('search-user-profile-img').src = userProfileData.profile.profile_img_route;
+}
+
 function searchUserProfile(){
     const urlParams = new URLSearchParams(window.location.search);
     const searchQuery = urlParams.get('query');
@@ -89,6 +97,7 @@ function searchUserProfile(){
         }
         const userProfileData = data.userData[0];
         setUserProfile(userProfileData.userData);
+        setUserProfileImg(userProfileData)
         setSNSIcon(userProfileData);
         setProfileMessage(userProfileData);
         setJoinedClubs(userProfileData);

--- a/app/src/views/assets/js/search/user_search_result.js
+++ b/app/src/views/assets/js/search/user_search_result.js
@@ -9,7 +9,7 @@ function createCard(user, cardIndex) {
             <a href="search-user-profile?query=${user.user_id}" class="card-link">
                 <div class="row g-0">
                     <div class="col-md-4 d-flex align-items-center justify-content-center">
-                        <img src="./../../assets/img/default-profile-img.png" class="img-fluid rounded-start">
+                        <img src="${user.profile_img_route}" class="img-fluid rounded-start">
                     </div>
                     <div class="col-md-8">
                         <div class="card-body pt-4">
@@ -63,11 +63,7 @@ function searchUserResult() {
             return res.json();
         })
         .then(data => {
-            if (!data.success) {
-                return createNoResultMessage('검색 결과가 없습니다. 확인후 다시 검색해주세요.');
-            }
-            const users = data.result;
-            users.forEach((user, index) => {
+            data.forEach((user, index) => {
                 createCard(user, index);
             });
         })

--- a/app/src/views/ejs-file/pages-search/user_search_profile.ejs
+++ b/app/src/views/ejs-file/pages-search/user_search_profile.ejs
@@ -24,7 +24,7 @@
             <div class="card">
               <div class="card-body profile-card pt-4 d-flex flex-column align-items-center">
 
-                <img src="./../assets/img/default-profile-img.png" alt="Profile" class="rounded-circle">
+                <img id="search-user-profile-img" src="./../assets/img/default-profile-img.png" alt="Profile" class="rounded-circle">
                 <h2 id="userName"></h2>
                 <h3 id="userDepartment"></h3>
                 <div class="social-links mt-2">

--- a/app/src/views/ejs-file/partials/header.ejs
+++ b/app/src/views/ejs-file/partials/header.ejs
@@ -281,7 +281,7 @@
         <% if (userData.isAvailable) { %>
           <li class="nav-item dropdown pe-3">
             <a class="nav-link d-flex align-items-center pe-0" href="#" data-bs-toggle="dropdown">
-              <i class="bi bi-person-circle" style="font-size: 20px;"></i>
+              <img id="header-profile-img" src="./../../assets/img/default-profile-img.png" alt="Profile" class="rounded-circle" style="width: 38px;">
               <span class="d-none d-md-block dropdown-toggle ps-2">
                 <%= userData.user_name %>님 안녕하세요!
               </span>
@@ -350,4 +350,5 @@
       </ul>
     </nav><!-- End Icons Navigation -->
     <script defer src="../../assets/js/search/header_search.js"></script>
+    <script defer src="../../assets/js/profile/headerProfileImg.js"></script>
   </header><!-- End Header -->

--- a/app/src/views/ejs-file/users-profile.ejs
+++ b/app/src/views/ejs-file/users-profile.ejs
@@ -24,7 +24,7 @@
             <div class="card">
               <div class="card-body profile-card pt-4 d-flex flex-column align-items-center">
 
-                <img src="./../assets/img/default-profile-img.png" alt="Profile" class="rounded-circle">
+                <img id="profile-img" src="./../assets/img/default-profile-img.png" alt="Profile" class="rounded-circle">
                 <h2>
                   <%= userData.user_name %>
                 </h2>
@@ -144,15 +144,18 @@
                       <div class="row mb-3">
                         <label for="profileImageInput" class="col-md-4 col-lg-3 col-form-label">프로필 사진</label>
                         <div class="col-md-8 col-lg-9">
-                          <img src="./../assets/img/default-profile-img.png" alt="Profile">
-                          <div class="pt-2">
-                            <a href="#" class="btn btn-primary btn-sm" title="Upload new profile image"><i
-                                class="bi bi-upload"></i></a>
-                            <a href="#" class="btn btn-danger btn-sm" title="Remove my profile image"><i
-                                class="bi bi-trash"></i></a>
-                          </div>
+                            <img id="profile-edit-img" src="./../assets/img/default-profile-img.png" alt="Profile">
+                            <input type="file" id="profileImageInput" style="display:none" accept="image/*">
+                            <div class="pt-2">
+                                <button id="upload-profile-btn" class="btn btn-primary btn-sm" title="Upload new profile image">
+                                    <i class="bi bi-upload"></i>
+                                </button>
+                                <button id="delete-profile-btn" class="btn btn-danger btn-sm" title="Remove my profile image">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </div>
                         </div>
-                      </div>
+                    </div>
 
                       <!-- <div class="row mb-3">
                         <label for="fullName" class="col-md-4 col-lg-3 col-form-label">이름</label>
@@ -344,6 +347,17 @@
           </div>
         </div>
       </div>
+
+      <!-- 로딩 스피너 -->
+      <div id="loading-spinner" style="display: none;">
+        <div class="spinner">
+            <div class="circle"></div>
+            <div class="circle"></div>
+            <div class="circle"></div>
+            <div class="circle"></div>
+        </div>
+    </div>
+    
     </main><!-- End #main -->
 
     <!-- ======= Footer ======= -->


### PR DESCRIPTION
<클라우드 저장소를 이용한 유저 개인 프로필 사진 기능 구현 완료>

1. 자신의 프로필 페이지, 
헤더의 프로필 사진, 
검색을 통한 프로필 사진, 
검색을 통해 들어간 다른 유저의 프로필 ,
사진에 모두 연동이 되었습니다.

2. 프로필 사진이 없는경우는 기본 디폴트 사진으로 적용됩니다.

3. 프로필 사진 변경은 프로필 편집에서 가능합니다.

4. 업로드 버튼을 누르면 프로필 사진을 고를수 있고, 삭제하기 버튼을 누르면 기본 디폴트 프로필 사진으로 저장됩니다.

5. DB에서 유저 프로필 사진 경로는 아무것도 지정안하면 클라우드의 디폴트 프로필 사진 경로가 저장됩니다.
![개인프로필](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/40bc5ba9-9de2-490d-8db8-345d0273e97a)
![프로필 편집](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/a28fc8c2-126b-4c7a-addb-de0a5cccd965)
![프로필 검색 결과](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/758a3686-55c9-4d80-b233-751b00aeb9a6)
![프로필 검색해서 들어간 유저 프로필](https://github.com/flej3/Dong_a_ri_Da_rak_bang/assets/53421936/b01e6a86-d38d-4955-8b78-f4855955a4ba)
