### PR TITLE
<동아리 프로필 사진 설정 (클라우드)>:

### DIFF
--- a/app/src/controllers/clubIntroductionControllers/clubIntroduction.ctrl.js
+++ b/app/src/controllers/clubIntroductionControllers/clubIntroduction.ctrl.js
@@ -19,10 +19,10 @@ const getClubIntroduction = async (req, res) => {
 const saveClubIntroEdit = async (req, res) => {
     const resData = {};
     try {
-        const {about, twitter, facebook, instagram, category} = req.body;
-        const query = `UPDATE club SET about = ?, twitter_link = ?, facebook_link = ?, instagram_link = ? WHERE category = ?; `;
+        const {profile_img_route, about, twitter, facebook, instagram, category} = req.body;
+        const query = `UPDATE club SET profile_img_route = ?, about = ?, twitter_link = ?, facebook_link = ?, instagram_link = ? WHERE category = ?; `;
 
-        await executeQueryPromise(query, [about, twitter, facebook, instagram, category]);
+        await executeQueryPromise(query, [profile_img_route, about, twitter, facebook, instagram, category]);
 
         resData.success = true;
         res.status(200).json(resData);

--- a/app/src/views/assets/js/clubIntroPage/clubs_introduction.js
+++ b/app/src/views/assets/js/clubIntroPage/clubs_introduction.js
@@ -6,8 +6,10 @@ function getCategory() {
 }
 
 function fillClubData(clubData){
-    const { club_name, club_owner, affilition, about, twitter_link, facebook_link, instagram_link } = clubData;
-
+    // const {profile_img_route, club_name, club_owner, affilition, about, twitter_link, facebook_link, instagram_link } = clubData;
+    const { club_name, club_owner, affilition, about, twitter_link, facebook_link, instagram_link, profile_img_route } = clubData;
+    console.log(profile_img_route)
+    document.getElementById('club-introduction-profile-img').src = profile_img_route;
     document.getElementById('clubName').innerText = `동아리명 : ${club_name}`;
     document.getElementById('clubAffilition').innerText = `소속 : ${affilition}`;
     document.getElementById('clubAbout').innerText = about;

--- a/app/src/views/assets/js/clubProfile/clubProfile.js
+++ b/app/src/views/assets/js/clubProfile/clubProfile.js
@@ -48,7 +48,7 @@ async function createClubCard(club) {
     <div class="col-md-4 mb-4 team-card">
         <a href="/Page-clubAdmin?query=${club.category}" style="margin: auto;">
         <div class="card h-100">
-            <img src="../../assets/img/hs-logo.png" alt="">
+            <img id="club-introduction-page-profile-img-${club.category}" src="${club.profile_img_route}" alt="Profile" class="rounded-circle" style="width: 300px;">
             <div class="card-body profile-card">
                 <h2 class="card-title text-center">동아리명: ${club.club_name}<br/>담당자: ${club.user_name}</h2>
                 <h3 class="card-subtitle mb-3 text-center">나의 직위: ${club.position}</h3>

--- a/app/src/views/assets/js/pagesAdmin/club_introduction_tab.js
+++ b/app/src/views/assets/js/pagesAdmin/club_introduction_tab.js
@@ -11,6 +11,7 @@ function fillClubIntro(clubIntroData) {
     const facebookLink = facebook_link || '';
     const instagramLink = instagram_link || '';
 
+    document.getElementById('profile-edit-img').src = profile_img_route;
     document.getElementById('clubIntroMsg').innerHTML = aboutWithLineBreaks;
     document.getElementById('clubMessage').value = about || '';
     document.getElementById('clubTwitterProfile').value = twitterLink;
@@ -69,8 +70,11 @@ document.getElementById('saveClubProfileBtn').addEventListener('click', async (e
     await saveClubIntroEdit(editClubIntroData);
 })
 
+const profileEditImg = document.getElementById('profile-edit-img');
+
 function getEditClubIntroData() {
     const clubIntroData = {};
+    clubIntroData.profile_img_route = profileEditImg.src;
     clubIntroData.about = document.getElementById('clubMessage').value;
     clubIntroData.twitter = document.getElementById('clubTwitterProfile').value;
     clubIntroData.facebook = document.getElementById('clubFacebookProfile').value;
@@ -124,6 +128,86 @@ async function isClubAdminAc() {
         window.location.reload();
     }
 }
+
+// Cloudinary 이미지 업로드 함수
+async function uploadProfileImageToCloudinary(file) {
+    const formData = new FormData();
+    formData.append('file', file);
+    const cloudName = await getEnvCloudName();
+    formData.append('upload_preset', 'gh4pwyaw');
+    formData.append('cloud_name', cloudName);
+
+    // 로딩 스피너 표시
+    document.getElementById('loading-spinner').style.display = 'block';
+
+    const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudName}/image/upload`, {
+        method: 'POST',
+        body: formData
+    });
+
+    // 로딩 스피너 숨기기
+    document.getElementById('loading-spinner').style.display = 'none';
+
+    if (!response.ok) {
+        throw new Error('이미지 업로드에 실패하였습니다.');
+    }
+
+    const data = await response.json();
+    return data.secure_url;
+}
+
+// 환경 변수에서 Cloudinary 클라우드 이름을 가져오는 함수
+async function getEnvCloudName() {
+    try {
+        const response = await fetch(`/api/get/env`, {
+            method: "GET",
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        if (!response.ok) {
+            throw new Error('네트워크 응답이 올바르지 않습니다.');
+        }
+        const data = await response.json();
+        return data.env;
+    } catch (error) {
+        alert(`에러발생: ${error}`);
+        window.location.href = "/";
+    }
+}
+
+// 프로필 이미지 업로드 및 삭제 이벤트 리스너 등록
+const profileImageInput = document.getElementById('clubImageInput');
+const uploadProfileBtn = document.getElementById('upload-profile-btn');
+const deleteProfileBtn = document.getElementById('delete-profile-btn');
+
+uploadProfileBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    profileImageInput.click();
+});
+
+profileImageInput.addEventListener('change', async () => {
+    const file = profileImageInput.files[0];
+    if (file) {
+        try {
+            const imageUrl = await uploadProfileImageToCloudinary(file);
+            profileEditImg.src = imageUrl; // 이미지 미리보기 업데이트
+        } catch (error) {
+            console.error('Error uploading profile image:', error);
+            alert('프로필 이미지 업로드에 실패했습니다.');
+        }
+    }
+});
+
+deleteProfileBtn.addEventListener('click', async (event) => {
+    event.preventDefault();
+    try {
+        profileEditImg.src = 'https://res.cloudinary.com/dtn8eum07/image/upload/v1716523504/kietouckugzsekobidcx.png'; // 기본 이미지로 변경
+    } catch (error) {
+        console.error('Error deleting profile image:', error);
+        alert('프로필 이미지 삭제에 실패했습니다.');
+    }
+});
 
 document.addEventListener('DOMContentLoaded', async () => {
     await getClubIntroduction();

--- a/app/src/views/assets/js/pagesAdmin/club_introduction_tab.js
+++ b/app/src/views/assets/js/pagesAdmin/club_introduction_tab.js
@@ -11,6 +11,7 @@ function fillClubIntro(clubIntroData) {
     const facebookLink = facebook_link || '';
     const instagramLink = instagram_link || '';
 
+    document.getElementById('club-profile-img').src = profile_img_route;
     document.getElementById('profile-edit-img').src = profile_img_route;
     document.getElementById('clubIntroMsg').innerHTML = aboutWithLineBreaks;
     document.getElementById('clubMessage').value = about || '';

--- a/app/src/views/assets/js/profile/profile_edit.js
+++ b/app/src/views/assets/js/profile/profile_edit.js
@@ -124,38 +124,6 @@ async function uploadProfileImageToCloudinary(file) {
     return data.secure_url;
 }
 
-// Cloudinary 이미지 삭제 함수
-// async function deleteProfileImageFromCloudinary() {
-//     const publicId = 'your_public_id'; // 예제용 public_id, 실제 사용 시 추적된 public_id로 대체
-//     const cloudName = await getEnvCloudName();
-
-//     // 로딩 스피너 표시
-//     document.getElementById('loading-spinner').style.display = 'block';
-
-//     const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudName}/image/destroy`, {
-//         method: 'POST',
-//         headers: {
-//             'Content-Type': 'application/json'
-//         },
-//         body: JSON.stringify({
-//             public_id: publicId
-//         })
-//     });
-
-//     // 로딩 스피너 숨기기
-//     document.getElementById('loading-spinner').style.display = 'none';
-
-//     if (!response.ok) {
-//         throw new Error('이미지 삭제에 실패하였습니다.');
-//     }
-
-//     const data = await response.json();
-//     if (data.result !== 'ok') {
-//         throw new Error('이미지 삭제 실패');
-//     }
-//     return data;
-// }
-
 // 환경 변수에서 Cloudinary 클라우드 이름을 가져오는 함수
 async function getEnvCloudName() {
     try {

--- a/app/src/views/ejs-file/page-club-introduction/page-club-introduction.ejs
+++ b/app/src/views/ejs-file/page-club-introduction/page-club-introduction.ejs
@@ -23,8 +23,7 @@
                 <span id="likeCount">0</span>
               </a>
               <div class="card-body profile-card pt-4 d-flex flex-column align-items-center">
-                <img src="assets/img/hs-logo.png" alt="Profile" class="rounded-circle">
-                <h2 id="clubName">동아리명 : -</h2>
+                <img id="club-introduction-profile-img" src="assets/img/hs-logo.png" alt="Profile" class="rounded-circle" style="width: 300px;">                <h2 id="clubName">동아리명 : -</h2>
                 <!-- 소속은 고정이 아님. 동아리장이 컴공이라고해서 해당 동아리가 컴공 소속이지 않다는 뜻 -->
                 <h3 id="clubAffilition">소속 : -</h3>
                 <div class="social-links mt-2">

--- a/app/src/views/ejs-file/pages-clubAdmin.ejs
+++ b/app/src/views/ejs-file/pages-clubAdmin.ejs
@@ -24,7 +24,7 @@
                         <span id="likeCount">0</span>
                     </a>
                     <div class="card-body profile-card pt-4 d-flex flex-column align-items-center">
-                        <img src="assets/img/hs-logo.png" alt="Profile" class="rounded-circle">
+                        <img id="club-profile-img" src="assets/img/hs-logo.png" alt="Profile" class="rounded-circle" style="width: 300px;">
                         <h2>동아리명 : <%= club.club_name%> </h2>
                         <!--소속은 고정이 아님. 동아리장이 컴공이라고해서
                         해당 동아리가 컴공 소속이지 않다는 뜻!-->

--- a/app/src/views/ejs-file/pages-clubAdmin.ejs
+++ b/app/src/views/ejs-file/pages-clubAdmin.ejs
@@ -251,10 +251,15 @@
                                     <div class="row mb-3">
                                         <label for="clubImageInput" class="col-md-4 col-lg-3 col-form-label">클럽 사진</label>
                                         <div class="col-md-8 col-lg-9">
-                                            <img src="./../assets/img/hs-logo.png" alt="Profile" style="width: 100px; height: auto;">
+                                            <img id="profile-edit-img" src="./../assets/img/hs-logo.png" alt="Profile" style="width: 300px;">
+                                            <input type="file" id="clubImageInput" style="display:none" accept="image/*">
                                             <div class="pt-2">
-                                                <a href="#" class="btn btn-primary btn-sm" title="새로운 클럽 사진 업로드"><i class="bi bi-upload"></i></a>
-                                                <a href="#" class="btn btn-danger btn-sm" title="클럽 사진 삭제"><i class="bi bi-trash"></i></a>
+                                                <button id="upload-profile-btn" class="btn btn-primary btn-sm" title="Upload new profile image">
+                                                    <i class="bi bi-upload"></i>
+                                                </button>
+                                                <button id="delete-profile-btn" class="btn btn-danger btn-sm" title="Remove my profile image">
+                                                    <i class="bi bi-trash"></i>
+                                                </button>
                                             </div>
                                         </div>
                                     </div>
@@ -486,6 +491,17 @@
             </div>
         </div>
     </div>
+
+    <!-- 로딩 스피너 -->
+    <div id="loading-spinner" style="display: none;">
+        <div class="spinner">
+            <div class="circle"></div>
+            <div class="circle"></div>
+            <div class="circle"></div>
+            <div class="circle"></div>
+        </div>
+    </div>
+
 </main><!-- End #main -->
 
 <!-- ======= Footer ======= -->


### PR DESCRIPTION
<동아리 프로필 사진 설정 (클라우드)>:


1.  동아리 메인 프로필 사진은 동아리 관리 페이지에서 "동아리 소개 편집" 텝에서 사용 가능합니다.

2. 이미지가 업로드 되는 동안(클라우드에 올라가는 동안) 로딩바가 생깁니다.

3. 해당 이미지를 저장 하면 이제 해당 동아리의 마크가 기본 "한신대 로고" 에서 변경한 사진으로 바뀝니다.

4. 기존에 동아리 마크인 한신대 로고가 출력 되던 모든 곳에서 변경된 동아리 로고 사진이 출력됩니다.

5. "동아리 소개 편집"에서 클럽 사진 아래쪽에 "휴지통" 버튼을 누르면 기본 한신대 로고 사진으로 변경됩니다.

6. DB에서 동아리가 만들어지면 기본적으로 "club"테이블에 "profile_img_route"컬럼이 클라우드에 올라가있는 기본 한신대 로고로 지정됩니다.